### PR TITLE
Remove space before question mark

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,22 +5,22 @@
 
 [![View performance data on Skylight](https://badges.skylight.io/status/nz7MAOv6K6ra.svg)](https://oss.skylight.io/app/applications/nz7MAOv6K6ra) [![View performance data on Skylight](https://badges.skylight.io/rpm/nz7MAOv6K6ra.svg)](https://oss.skylight.io/app/applications/nz7MAOv6K6ra) [![View performance data on Skylight](https://badges.skylight.io/problem/nz7MAOv6K6ra.svg)](https://oss.skylight.io/app/applications/nz7MAOv6K6ra) [![View performance data on Skylight](https://badges.skylight.io/typical/nz7MAOv6K6ra.svg)](https://oss.skylight.io/app/applications/nz7MAOv6K6ra)
 
-## What is Trefle ?
+## What is Trefle?
 
 🍀 Trefle is a botanical JSON REST API for plants species, allowing you to search and query over all the registered species, and build the next gardening apps and farming robots.
 
-## Why this repo ?
+## Why this repo?
 
 The purpose of this repository is:
 - To offer an accessible channel to collect issues and ideas.
 - To show our public roadmap, the current topics and features to come.
 
-## How to contribute ?
+## How to contribute?
 
 ### 🚨 There is a bug
 
-[Please create a new bug report !](https://github.com/treflehq/trefle-api/issues/new?assignees=&labels=&template=bug_report.md&title=) ! We will look at it, make sure it's not a duplicate, then it will go into our [Issues board](https://github.com/orgs/treflehq/projects/2)
+[Please create a new bug report!](https://github.com/treflehq/trefle-api/issues/new?assignees=&labels=&template=bug_report.md&title=) We will look at it, make sure it's not a duplicate, then it will go into our [Issues board](https://github.com/orgs/treflehq/projects/2)
 
 ### 💡 I have a feature idea
 
-[Please create a new feature request !](https://github.com/treflehq/trefle-api/issues/new?assignees=&labels=&template=feature_request.md&title=) We will look at it, make sure it's not a duplicate, then it will go into our [Ideas and features board](https://github.com/orgs/treflehq/projects/3)
+[Please create a new feature request!](https://github.com/treflehq/trefle-api/issues/new?assignees=&labels=&template=feature_request.md&title=) We will look at it, make sure it's not a duplicate, then it will go into our [Ideas and features board](https://github.com/orgs/treflehq/projects/3)


### PR DESCRIPTION
In English, it is always an error. There should be no space between a sentence and its ending punctuation, whether that's a period, a question mark, or an exclamation mark. There should also be no space before a colon, semicolon, or comma.