### PR TITLE
Upgrade Skylight gem to 5.0beta

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,7 @@ gem 'pghero'
 gem 'pg_query', '>= 0.9.0'
 gem 'rack-attack', '~> 6.2.2'
 gem 'sentry-raven'
-gem 'skylight'
+gem 'skylight', '~> 5.0.0.beta4'
 
 # Sidekiq
 gem 'redis', '~> 4.1.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -386,10 +386,8 @@ GEM
     sitemap_generator (6.1.2)
       builder (~> 3.0)
     sixarm_ruby_unaccent (1.2.0)
-    skylight (4.3.1)
-      skylight-core (= 4.3.1)
-    skylight-core (4.3.1)
-      activesupport (>= 4.2.0)
+    skylight (5.0.0.beta4)
+      activesupport (>= 5.2.0)
     spring (2.1.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -505,7 +503,7 @@ DEPENDENCIES
   sidekiq-status
   simplecov (>= 0.16.1)
   sitemap_generator
-  skylight
+  skylight (~> 5.0.0.beta4)
   spring
   spring-watcher-listen (>= 2.0.0)
   terminal-table


### PR DESCRIPTION
Thank you so much for participating in the [Skylight for Open Source](https://www.skylight.io/oss) program. We'd like to invite Trefle to participate in the public alpha for Source Locations for Skylight!

With this new feature, Skylight can help you pinpoint the locations in your code that correspond to events in the Skylight Event Sequence. This feature will allow your contributors to more easily find out exactly where an expensive operation originated without having to scour your code.

![https://d2ryfneqiwuan6.cloudfront.net/assets/skylight/docs/features/source-locations-popover-1181b5debba553a2b06bd914405997dce0334388b69fe3877c30acc21393ca25.png](https://d2ryfneqiwuan6.cloudfront.net/assets/skylight/docs/features/source-locations-popover-1181b5debba553a2b06bd914405997dce0334388b69fe3877c30acc21393ca25.png)

When you merge this PR, we will enable the feature flag for you on Skylight's servers. Then, once you deploy, you should begin seeing source locations data shortly after.

You can find documentation about the new feature at [https://www.skylight.io/support/source-locations](https://www.skylight.io/support/source-locations), and as always, if you have any questions or feedback, please get in touch with us either by responding here, emailing [support@skylight.io](mailto:support@skylight.io), or via the in-app communicator at the lower-right of your Skylight dashboard.