### PR TITLE
Remove restrictions on rubocop ruby version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,4 @@
-
 AllCops:
-  TargetRubyVersion: 2.6
   Exclude:
     - 'vendor/**/*'
     - 'node_modules/**/*'


### PR DESCRIPTION
We are on ruby 3.1 [.ruby-version](https://github.com/treflehq/trefle-api/blob/master/.ruby-version).

Rubocop supports `.ruby-version` lookup, so we don't need to define it and keep it up to date.

https://docs.rubocop.org/rubocop/1.56/configuration.html#setting-the-target-ruby-version

It'll enable better cop support for newer ruby functionality.