### PR TITLE
Load Rails 7.1 framework defaults

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -24,7 +24,7 @@ module TrefleAdmin
     VERSION = '1.7.0'.freeze
 
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 7.0
+    config.load_defaults 7.1
 
     # Configuration for the application, engines, and railties goes here.
     #


### PR DESCRIPTION
Follow-up to #186: the app now runs the defaults matching its Rails version.

No `serialize` columns and no overridden flags, so the notable changes are the SHA256 message digests (outstanding signed cookies invalidated once more) and the 7.1 cache format.

Suite: 599 examples, 0 failures.