### PR TITLE
Load Rails 7.2 framework defaults

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -24,7 +24,7 @@ module TrefleAdmin
     VERSION = '1.7.0'.freeze
 
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 7.1
+    config.load_defaults 7.2
 
     # Configuration for the application, engines, and railties goes here.
     #


### PR DESCRIPTION
Follow-up to #188. Notable defaults picked up: YJIT enabled when available, `Regexp.timeout`, safer postgres reconnect handling. No overridden flags in the app.

Suite: 599 examples, 0 failures.