### PR TITLE
Upgrade Sidekiq to 7.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,9 +73,8 @@ gem "skylight"
 
 # Sidekiq
 gem 'redis', '>= 4.1.4'
-gem 'redis-namespace', '>= 1.7.0'
 gem 'rufus-scheduler', '>= 3.4.2'
-gem 'sidekiq', '< 7'
+gem 'sidekiq', '~> 7.3'
 gem 'sidekiq-cron', '>= 0.6.3'
 gem 'sidekiq-limit_fetch'
 gem 'sidekiq-status'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -454,8 +454,6 @@ GEM
       redis-client (>= 0.22.0)
     redis-client (0.27.0)
       connection_pool
-    redis-namespace (1.11.0)
-      redis (>= 4)
     regexp_parser (2.11.3)
     reline (0.6.3)
       io-console (~> 0.5)
@@ -545,20 +543,24 @@ GEM
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
       logger
-    sidekiq (6.5.5)
-      connection_pool (>= 2.2.2)
-      rack (~> 2.0)
-      redis (>= 4.5.0)
-    sidekiq-cron (2.3.1)
+    sidekiq (7.3.10)
+      base64
+      connection_pool (>= 2.3.0, < 3)
+      logger
+      rack (>= 2.2.4, < 3.3)
+      redis-client (>= 0.23.0, < 1)
+    sidekiq-cron (2.4.0)
       cronex (>= 0.13.0)
       fugit (~> 1.8, >= 1.11.1)
       globalid (>= 1.0.1)
       sidekiq (>= 6.5.0)
     sidekiq-limit_fetch (4.4.1)
       sidekiq (>= 6)
-    sidekiq-status (3.0.3)
+    sidekiq-status (4.0.0)
+      base64
       chronic_duration
-      sidekiq (>= 6.0, < 8)
+      logger
+      sidekiq (>= 7, < 9)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -681,7 +683,6 @@ DEPENDENCIES
   rails-controller-testing
   recaptcha
   redis (>= 4.1.4)
-  redis-namespace (>= 1.7.0)
   rspec
   rspec-rails
   rswag
@@ -693,7 +694,7 @@ DEPENDENCIES
   selenium-webdriver
   sentry-rails
   sentry-ruby
-  sidekiq (< 7)
+  sidekiq (~> 7.3)
   sidekiq-cron (>= 0.6.3)
   sidekiq-limit_fetch
   sidekiq-status

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,8 +1,7 @@
----
-:concurrency: 5
+concurrency: 5
 production:
-  :concurrency: 5
-:queues:
+  concurrency: 5
+queues:
   - critical
   - default
   - checks
@@ -11,7 +10,7 @@ production:
   - searchkick
   - low
   - crawlers
-:process_limits:
+process_limits:
   critical: 4
   default: 3
   crawlers: 3


### PR DESCRIPTION
Prerequisite for Rails 8 (sidekiq < 7 was the main blocker).

- sidekiq 6.5 → 7.3.10, sidekiq-cron 2.4, sidekiq-status 4.0, sidekiq-limit_fetch 4.4 — every plugin resolved to a Sidekiq-7-compatible version, the `process_limits` throttling is preserved.
- `sidekiq.yml` loses its leading-colon keys (symbol YAML keys removed in Sidekiq 7).
- `redis-namespace` removed: no caller anywhere in the codebase.

**Deploy note**: jobs enqueued by Sidekiq 6 in Redis are compatible with 7; the web UI at /management/sidekiq keeps working. Verified locally: worker boots, cron schedule and queue limits load. Suite: 599 examples, 0 failures.