### PR TITLE
Load Rails 8.0 framework defaults

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -24,7 +24,7 @@ module TrefleAdmin
     VERSION = '1.7.0'.freeze
 
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 7.2
+    config.load_defaults 8.0
 
     # Configuration for the application, engines, and railties goes here.
     #


### PR DESCRIPTION
Completes the staged upgrade started at Rails 7.0 with 6.0 defaults: gems and framework defaults are now both on 8.0.

Picks up `to_time_preserves_timezone = :zone`, clearing the last active_support deprecation. Only rswag's `swagger_*` naming warnings remain, for a future rswag bump.

Suite: 599 examples, 0 failures.