### PR TITLE
Cover resolvers, sponsorship and migrators; ban network access in specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -107,6 +107,7 @@ gem "recaptcha"
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'brakeman', require: false
+  gem 'webmock'
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'rubocop', require: false
   gem 'rubocop-rails', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,6 +117,9 @@ GEM
       activesupport (>= 4.2)
     countries (8.1.0)
       unaccent (~> 0.3)
+    crack (1.0.1)
+      bigdecimal
+      rexml
     crass (1.0.6)
     cronex (0.15.0)
       tzinfo
@@ -224,6 +227,7 @@ GEM
     has_scope (0.9.0)
       actionpack (>= 7.0)
       activesupport (>= 7.0)
+    hashdiff (1.2.1)
     hashie (5.1.0)
       logger
     health_check (3.1.0)
@@ -602,6 +606,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webmock (3.26.4)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.9.2)
     websocket (1.2.11)
     websocket-driver (0.8.1)
@@ -703,6 +711,7 @@ DEPENDENCIES
   typhoeus
   tzinfo-data
   web-console (>= 3.3.0)
+  webmock
 
 BUNDLED WITH
    2.6.9

--- a/lib/resolver/gbif.rb
+++ b/lib/resolver/gbif.rb
@@ -35,15 +35,9 @@ module Resolver
 
         confidence = match[:confidence]
 
-        if confidence <= 90
-          puts "Confidence is too low: #{confidence}, skipping..."
-          return
-        end
-
-        puts "#{match[:taxonomicStatus]}: #{match.inspect}"
+        return if confidence <= 90
 
         if match[:synonym]
-          puts "Synonym: #{match.inspect}"
           syn = fetch_species(match[:key])
           match = fetch_species(syn[:acceptedKey])
         else
@@ -54,8 +48,6 @@ module Resolver
 
         return if match[:kingdom] != 'Plantae'
         return if match[:taxonomicStatus] != 'ACCEPTED'
-
-        pp match
 
         match[:main_species] = nil
         match[:confidence] = confidence
@@ -81,7 +73,6 @@ module Resolver
         )
         return unless r.ok?
 
-        puts "[GBIF] [#{scientific_name}] Adding #{r.parsed_response['speciesMatches']['count']} items"
         datas = r.parsed_response['speciesMatches']['results']
 
         data = datas&.reject {|e| e['rank'] == 'GENUS' }&.first&.deep_symbolize_keys
@@ -94,7 +85,6 @@ module Resolver
         r = get("/taxonomy/#{DATASET_KEY}/#{id}")
         return unless r.ok?
 
-        puts "[GBIF] [#{id}] Fetched"
         r.parsed_response&.deep_symbolize_keys
       end
 
@@ -118,7 +108,6 @@ module Resolver
         rank = :hybrid if scientific_name&.match(/ × /) && rank == :species
 
         authorship = clean_authorship(entry[:authorship])
-        pp authorship
         {
           scientific_name: scientific_name,
           rank: rank,

--- a/lib/resolver/powo.rb
+++ b/lib/resolver/powo.rb
@@ -49,7 +49,6 @@ module Resolver
         )
         return unless r.ok?
 
-        puts "[POWO] [#{scientific_name}] Adding #{r.parsed_response['totalResults']} items"
         data = r.parsed_response['results']&.filter {|e| e['accepted'] && e['rank'] != 'Genus' }&.first&.deep_symbolize_keys
         Rails.cache.write("resolver/powo/search/#{scientific_name}", data.to_json, expires_in: 12.hours)
         data
@@ -60,7 +59,6 @@ module Resolver
         r = get("/taxonomy/#{DATASET_KEY}/#{id}")
         return unless r.ok?
 
-        puts "[POWO] [#{id}] Fetched"
         r.parsed_response&.deep_symbolize_keys
       end
 

--- a/lib/sponsorship/github_sponsorship.rb
+++ b/lib/sponsorship/github_sponsorship.rb
@@ -48,10 +48,7 @@ class Sponsorship::GithubSponsorship
 
     response = http.request(request)
 
-    puts response.inspect
     data = JSON.parse(response.body)
-
-    puts data.inspect
 
     # Navigue dans la structure de la réponse GraphQL
     sponsorship = data.dig('data', 'organization', 'sponsorshipsAsMaintainer', 'nodes')
@@ -68,7 +65,6 @@ class Sponsorship::GithubSponsorship
     User.where.not(sponsored_tier: nil, github_username: sponsors.keys).update_all(sponsored_tier: nil)
 
     sponsors.each do |github_login, tier_amount|
-      puts "Adding #{github_login} with tier #{tier_amount}"
       User.find_by(github_username: github_login)&.update(sponsored_tier: tier_amount)
     end
   end

--- a/spec/lib/migrators_spec.rb
+++ b/spec/lib/migrators_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe Migrators do
+  describe Migrators::Slugs do
+    it 'regenerates missing slugs' do
+      species = Species.friendly.find('abies-alba')
+      species.update_columns(slug: nil)
+
+      described_class.run
+
+      expect(species.reload.slug).to eq('abies-alba')
+    end
+  end
+
+  describe Migrators::MainSpecies do
+    it 'attaches an infraspecific name to its main species' do
+      main = Species.friendly.find('abies-alba')
+      variety = Species.create!(
+        genus: main.genus,
+        rank: 'var',
+        scientific_name: 'Abies alba var. minora'
+      )
+      variety.update_columns(main_species_id: nil)
+
+      described_class.run
+
+      expect(variety.reload.main_species_id).to eq(main.id)
+    end
+  end
+
+  describe Migrators::SynonymsDuplicates do
+    it 'merges a species whose name is a registered synonym of another' do
+      keeper = Species.friendly.find('abies-alba')
+      synonym_name = keeper.synonyms.first.name
+      duplicate = Species.create!(
+        genus: keeper.genus,
+        rank: 'species',
+        scientific_name: synonym_name
+      )
+
+      described_class.run
+
+      expect(Species.exists?(duplicate.id)).to be(false)
+      expect(Species.exists?(keeper.id)).to be(true)
+    end
+  end
+end

--- a/spec/lib/resolver_spec.rb
+++ b/spec/lib/resolver_spec.rb
@@ -1,0 +1,133 @@
+require 'rails_helper'
+
+RSpec.describe Resolver::Gbif do
+  def stub_omnisearch(name, results)
+    stub_request(:get, 'https://www.gbif.org/api/omnisearch')
+      .with(query: { locale: 'en', q: name })
+      .to_return(
+        status: 200,
+        headers: { 'Content-Type' => 'application/json' },
+        body: { speciesMatches: { count: results.size, results: results } }.to_json
+      )
+  end
+
+  def stub_taxon(id, body)
+    stub_request(:get, "https://www.gbif.org/api/taxonomy/#{described_class::DATASET_KEY}/#{id}")
+      .to_return(status: 200, headers: { 'Content-Type' => 'application/json' }, body: body.to_json)
+  end
+
+  let(:gbif_entry) do
+    {
+      key: 2_685_484, speciesKey: 2_685_484, rank: 'SPECIES', confidence: 98,
+      synonym: false, scientificName: 'Abies alba Mill.', authorship: 'Mill.',
+      kingdom: 'Plantae', taxonomicStatus: 'ACCEPTED', genus: 'Abies',
+      publishedIn: 'Gard. Dict. ed. 8: n.º 1 (1768)'
+    }
+  end
+
+  describe '.resolve_hash' do
+    it 'resolves an accepted name' do
+      stub_omnisearch('Abies alba', [gbif_entry])
+      stub_taxon(2_685_484, gbif_entry)
+
+      result = described_class.resolve_hash('Abies alba')
+
+      expect(result).to include(
+        scientific_name: 'Abies alba',
+        rank: :species,
+        genus: 'Abies',
+        source_gbif: 2_685_484,
+        status: 'accepted'
+      )
+    end
+
+    it 'ignores low confidence matches' do
+      stub_omnisearch('Abies dubium', [gbif_entry.merge(confidence: 42)])
+
+      expect(described_class.resolve_hash('Abies dubium')).to be_nil
+    end
+
+    it 'ignores non-plant kingdoms' do
+      stub_omnisearch('Felis catus', [gbif_entry.merge(kingdom: 'Animalia')])
+      stub_taxon(2_685_484, gbif_entry.merge(kingdom: 'Animalia'))
+
+      expect(described_class.resolve_hash('Felis catus')).to be_nil
+    end
+
+    it 'follows synonyms to the accepted species' do
+      stub_omnisearch('Abies pectinata', [gbif_entry.merge(synonym: true, key: 111)])
+      stub_taxon(111, { acceptedKey: 2_685_484 })
+      stub_taxon(2_685_484, gbif_entry)
+
+      result = described_class.resolve_hash('Abies pectinata')
+
+      expect(result[:scientific_name]).to eq('Abies alba')
+    end
+
+    it 'returns nil when GBIF finds nothing' do
+      stub_omnisearch('Nothingus atallus', [])
+
+      expect(described_class.resolve_hash('Nothingus atallus')).to be_nil
+    end
+  end
+
+  describe '.clean_authorship' do
+    it 'splits the year out of the authorship' do
+      expect(described_class.clean_authorship('Mill., 1768')).to eq(author: 'Mill.', year: '1768')
+    end
+
+    it 'keeps a plain author' do
+      expect(described_class.clean_authorship('Mill.')).to eq(author: 'Mill.')
+    end
+
+    it 'accepts blanks' do
+      expect(described_class.clean_authorship(nil)).to eq({})
+    end
+  end
+end
+
+RSpec.describe Resolver::Powo do
+  def stub_search(name, results)
+    stub_request(:get, 'http://powo.science.kew.org/api/1/search')
+      .with(query: { q: name })
+      .to_return(
+        status: 200,
+        headers: { 'Content-Type' => 'application/json' },
+        body: { totalResults: results.size, results: results }.to_json
+      )
+  end
+
+  let(:powo_entry) do
+    {
+      name: 'Abies alba', author: 'Mill.', rank: 'Species', kingdom: 'Plantae',
+      accepted: true, fqId: 'urn:lsid:ipni.org:names:261578-1'
+    }
+  end
+
+  describe '.resolve_hash' do
+    it 'resolves an accepted name' do
+      stub_search('Abies alba', [powo_entry])
+
+      result = described_class.resolve_hash('Abies alba')
+
+      expect(result).to include(
+        scientific_name: 'Abies alba',
+        rank: :species,
+        status: 'accepted',
+        source_powo: 'urn:lsid:ipni.org:names:261578-1'
+      )
+    end
+
+    it 'skips names POWO does not accept' do
+      stub_search('Abies pectinata', [powo_entry.merge(accepted: false)])
+
+      expect(described_class.resolve_hash('Abies pectinata')).to be_nil
+    end
+
+    it 'returns nil when POWO finds nothing' do
+      stub_search('Nothingus atallus', [])
+
+      expect(described_class.resolve_hash('Nothingus atallus')).to be_nil
+    end
+  end
+end

--- a/spec/lib/sponsorship_spec.rb
+++ b/spec/lib/sponsorship_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe Sponsorship::GithubSponsorship do
+  def stub_sponsors(nodes)
+    stub_request(:post, 'https://api.github.com/graphql')
+      .to_return(
+        status: 200,
+        headers: { 'Content-Type' => 'application/json' },
+        body: { data: { organization: { sponsorshipsAsMaintainer: { nodes: nodes } } } }.to_json
+      )
+  end
+
+  let(:nodes) do
+    [
+      { sponsorEntity: { login: 'plantlover' }, tier: { monthlyPriceInDollars: 10 } },
+      { sponsorEntity: { login: 'agrocorp' }, tier: { monthlyPriceInDollars: 100 } }
+    ]
+  end
+
+  describe '.get_sponsors' do
+    it 'maps sponsor logins to their tier' do
+      stub_sponsors(nodes)
+
+      expect(described_class.get_sponsors).to eq('plantlover' => 10, 'agrocorp' => 100)
+    end
+
+    it 'returns nil without sponsors' do
+      stub_sponsors([])
+
+      expect(described_class.get_sponsors).to be_nil
+    end
+  end
+
+  describe '.reassign_sponsor_status' do
+    it 'sets the tier of current sponsors and clears ex-sponsors' do
+      sponsor = create(:user, github_username: 'plantlover')
+      ex_sponsor = create(:user, github_username: 'gonesponsor', sponsored_tier: '25')
+      stub_sponsors(nodes)
+
+      described_class.reassign_sponsor_status
+
+      expect(sponsor.reload.sponsored_tier).to eq('10')
+      expect(ex_sponsor.reload.sponsored_tier).to be_nil
+    end
+  end
+end
+
+RSpec.describe Sponsorship::UpdateSponsorWorker do
+  it 'delegates to the sponsorship reassignment' do
+    allow(Sponsorship::GithubSponsorship).to receive(:reassign_sponsor_status)
+
+    described_class.new.perform
+
+    expect(Sponsorship::GithubSponsorship).to have_received(:reassign_sponsor_status)
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -54,9 +54,11 @@ RSpec.configure do |config|
     ActiveRecord::Base.connection.execute("SELECT setval('foreign_sources_id_seq', (SELECT max(id) FROM foreign_sources));")
   end
 
-  # We don't want to be connected to internet
-  # WebMock.disable_net_connect!(allow_localhost: true)
-  # WebMock.allow_net_connect!
+  # No spec may reach the outside world (a shadowed Checks.run_all once
+  # called POWO/GBIF for real from CI); localhost stays open for
+  # OpenSearch.
+  require 'webmock/rspec'
+  WebMock.disable_net_connect!(allow_localhost: true)
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and


### PR DESCRIPTION
Second coverage push after #193.

- **WebMock** now blocks every external HTTP call from the suite (localhost stays open for OpenSearch) — the shadowed `run_all` episode showed specs could silently hit POWO/GBIF for real.
- **Resolver::Gbif / Resolver::Powo** specs against stubbed API payloads: accepted names, low confidence, synonym following, wrong kingdom, empty results, authorship parsing.
- **GithubSponsorship** against a stubbed GraphQL endpoint: tier mapping, ex-sponsor cleanup, worker delegation.
- **Migrators**: slug regeneration, main-species attachment, synonym duplicate merging.
- Leftover debug output removed from the resolvers and sponsorship.

Suite: 698 examples, 0 failures — line coverage **66%**.