### PR TITLE
Schedule a continuous data-quality sweep

### DIFF
--- a/app/workers/checks_sweep_worker.rb
+++ b/app/workers/checks_sweep_worker.rb
@@ -1,0 +1,18 @@
+# Feeds the data-quality checks continuously: every run picks the
+# species that have waited the longest (never checked first) and
+# enqueues a RunCheckWorker for each.
+class ChecksSweepWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :checks, retry: false, backtrace: true
+
+  DEFAULT_BATCH_SIZE = 200
+
+  def perform(batch_size = DEFAULT_BATCH_SIZE)
+    Species
+      .order(Arel.sql('checked_at ASC NULLS FIRST'))
+      .limit(batch_size)
+      .pluck(:id)
+      .each {|id| RunCheckWorker.perform_async(id) }
+  end
+end

--- a/app/workers/run_check_worker.rb
+++ b/app/workers/run_check_worker.rb
@@ -5,5 +5,8 @@ class RunCheckWorker
 
   def perform(species_id)
     ::Checks.run_all(species_id)
+    # Timestamp without callbacks so ChecksSweepWorker can rotate
+    # through the whole table oldest-first.
+    Species.where(id: species_id).update_all(checked_at: Time.zone.now) # rubocop:disable Rails/SkipsModelValidations
   end
 end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -20,6 +20,11 @@ update_sponsors:
   class: "Sponsorship::UpdateSponsorWorker"
   queue: low
 
+checks_sweep:
+  cron: "15 * * * *" # hourly, 200 least recently checked species
+  class: "ChecksSweepWorker"
+  queue: checks
+
 check_species_images:
   cron: "0 0 */7 * *" # At 00:00 on every 7th day-of-month.
   class: "Migrators::ImagesFixerWorker"

--- a/spec/workers/workers_spec.rb
+++ b/spec/workers/workers_spec.rb
@@ -19,6 +19,23 @@ RSpec.describe 'Recurring workers' do
 
       expect(RecordCorrection.pluck(:warning_type, :notes)).to eq([])
     end
+
+    it 'stamps checked_at so the sweep can rotate' do
+      expect { described_class.new.perform(species.id) }
+        .to change { species.reload.checked_at }.from(nil)
+    end
+  end
+
+  describe ChecksSweepWorker do
+    it 'enqueues the least recently checked species first' do
+      Species.update_all(checked_at: 1.day.ago)
+      species.update_columns(checked_at: nil)
+      allow(RunCheckWorker).to receive(:perform_async)
+
+      described_class.new.perform(1)
+
+      expect(RunCheckWorker).to have_received(:perform_async).with(species.id)
+    end
   end
 
   describe SpeciesRefreshWorker do


### PR DESCRIPTION
First automation of the data pipeline: the check system (fixed and covered in #193) now actually runs.

- `ChecksSweepWorker` (hourly via sidekiq-cron) picks the 200 least recently checked species — never-checked first — and enqueues `RunCheckWorker` for each.
- `RunCheckWorker` stamps `checked_at` (previously never written) so the sweep rotates through the whole table.
- The `checks` queue keeps its process limit of 3: the sweep cannot starve other queues.

At 200/hour the full table gets revisited roughly every 3 months; the batch size is a worker argument, easy to tune.