### PR TITLE
Move rswag configuration to the openapi_* names

### DIFF
--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -6,7 +6,7 @@ RSpec.configure do |config|
   # Specify a root folder where Swagger JSON files are generated
   # NOTE: If you're using the rswag-api to serve API descriptions, you'll need
   # to ensure that it's configured to serve Swagger from the same folder
-  config.swagger_root = Rails.root.join('swagger').to_s
+  config.openapi_root = Rails.root.join('swagger').to_s
 
   # Define one or more Swagger documents and provide global metadata for each one
   # When you run the 'rswag:specs:swaggerize' rake task, the complete Swagger will
@@ -14,7 +14,7 @@ RSpec.configure do |config|
   # By default, the operations defined in spec files are added to the first
   # document below. You can override this behavior by adding a swagger_doc tag to the
   # the root example_group in your specs, e.g. describe '...', swagger_doc: 'v2/swagger.json'
-  config.swagger_docs = {
+  config.openapi_specs = {
     'v1/swagger.yaml' => {
       openapi: '3.0.1',
       info: {
@@ -51,8 +51,8 @@ RSpec.configure do |config|
   }
 
   # Specify the format of the output Swagger file when running 'rswag:specs:swaggerize'.
-  # The swagger_docs configuration option has the filename including format in
+  # The openapi_specs configuration option has the filename including format in
   # the key, this may want to be changed to avoid putting yaml in json files.
   # Defaults to json. Accepts ':json' and ':yaml'.
-  config.swagger_format = :yaml
+  config.openapi_format = :yaml
 end


### PR DESCRIPTION
Closes #199.

rswag 2.17.0 turns out to be the latest published release (no 3.0 yet), so the gem bump part of the issue is a no-op; the deprecated `swagger_*` setters are renamed to their `openapi_*` equivalents, which removes the last deprecation warnings the suite printed.

Verified per the acceptance criteria:
- full suite green through `.agents/verify.sh` (rubocop + 698 examples), zero rswag deprecation lines
- `rake rswag:specs:swaggerize` still writes `swagger/v1/swagger.yaml`

Touches: spec/