### PR TITLE
Bump GitHub Actions to current major versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,13 +54,13 @@ jobs:
       REDIS_URL: redis://localhost:6379/1
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: lts/*
           cache: yarn
@@ -80,7 +80,7 @@ jobs:
     name: RuboCop
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
@@ -91,7 +91,7 @@ jobs:
     name: Brakeman
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,17 +13,17 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/metadata-action@v5
+      - uses: docker/metadata-action@v6
         id: meta
         with:
           images: ghcr.io/treflehq/api
@@ -31,7 +31,7 @@ jobs:
             type=semver,pattern={{version}}
             type=raw,value=latest
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .
           push: true


### PR DESCRIPTION
Closes #200.

Every action moved to its latest published major: checkout v7, setup-node v7, docker buildx v4, login v4, metadata v6, build-push v7. `ruby/setup-ruby` stays on its rolling `v1`. release.yml reviewed statically (same actions, tag trigger untouched).

The CI run on this PR is the real acceptance test: three green jobs and no Node.js deprecation annotation expected.

Touches: .github/workflows