### PR TITLE
Return 400 for unknown filter/order/range keys

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -1,6 +1,9 @@
 module Api
   class ApiController < ActionController::API
+    class UnknownQueryKeyError < StandardError; end
+
     rescue_from ActionController::BadRequest, with: :render_bad_request_response
+    rescue_from UnknownQueryKeyError, with: :render_unknown_query_key_response
     rescue_from ActiveRecord::RecordInvalid, with: :render_unprocessable_record_response
     rescue_from ActionController::ParameterMissing, with: :render_unprocessable_entity_response
     rescue_from ActiveRecord::RecordNotFound, with: :render_not_found_response
@@ -155,6 +158,10 @@ module Api
       render_error(exception.message, :unprocessable_entity)
     end
 
+    def render_unknown_query_key_response(exception)
+      render_error(exception.message, :bad_request)
+    end
+
     def render_not_found_response(exception)
       render_error(exception.message.gsub(' with friendly id', ''), :not_found)
     end
@@ -165,7 +172,7 @@ module Api
 
     def apply_filters(collection, filterable_fields)
       if params[:filter]&.is_a?(ActionController::Parameters)
-        collection.filter_with(params[:filter].permit(filterable_fields).slice(*filterable_fields))
+        collection.filter_with(permit_known_query_keys(:filter, filterable_fields))
       else
         collection
       end
@@ -204,7 +211,7 @@ module Api
 
     def apply_filters_not(collection, filterable_fields)
       if params[:filter_not]&.is_a?(ActionController::Parameters)
-        collection.filter_not_with(params[:filter_not].permit(filterable_fields).slice(*filterable_fields))
+        collection.filter_not_with(permit_known_query_keys(:filter_not, filterable_fields))
       else
         collection
       end
@@ -212,7 +219,7 @@ module Api
 
     def apply_sort(collection, orderable_fields, default_sort:)
       if params[:order]&.is_a?(ActionController::Parameters)
-        collection.sort_with(params[:order].permit(orderable_fields).slice(*orderable_fields))
+        collection.sort_with(permit_known_query_keys(:order, orderable_fields))
       else
         collection.order(default_sort)
       end
@@ -220,7 +227,7 @@ module Api
 
     def apply_range(collection, rangeable_fields)
       if params[:range]&.is_a?(ActionController::Parameters)
-        collection.range_with(params[:range].permit(rangeable_fields).slice(*rangeable_fields))
+        collection.range_with(permit_known_query_keys(:range, rangeable_fields))
       else
         collection
       end
@@ -232,6 +239,21 @@ module Api
       else
         collection
       end
+    end
+
+    # Raises UnknownQueryKeyError (rendered as 400) when `params[param_name]`
+    # contains a key outside `allowed_fields`, instead of silently dropping it
+    # like `permit`/`slice` would. Callers get valid keys back untouched.
+    def permit_known_query_keys(param_name, allowed_fields)
+      provided_params = params[param_name]
+      unknown_keys = provided_params.keys.map(&:to_s) - allowed_fields.map(&:to_s)
+
+      if unknown_keys.any?
+        raise UnknownQueryKeyError, "Unknown #{param_name} key#{'s' if unknown_keys.size > 1}: #{unknown_keys.join(', ')}. " \
+          "Valid #{param_name} keys are: #{allowed_fields.join(', ')}."
+      end
+
+      provided_params.permit(allowed_fields).slice(*allowed_fields)
     end
 
   end

--- a/spec/requests/api/v1/filter_validation_spec.rb
+++ b/spec/requests/api/v1/filter_validation_spec.rb
@@ -1,0 +1,120 @@
+require 'rails_helper'
+
+describe 'Filter/order/range key validation', type: :request do
+  let(:user) { create(:user) }
+  let(:headers) { {} }
+
+  def get_json(path, params)
+    get path, params: params.merge(token: user.token), headers: headers
+    JSON.parse(response.body)
+  end
+
+  describe 'GET /api/v1/species' do
+    it 'rejects an unknown filter_not key with a 400 naming the key' do
+      body = get_json('/api/v1/species', filter_not: { spread: 'null' })
+
+      expect(response).to have_http_status(:bad_request)
+      expect(body['error']).to eq(true)
+      expect(body['message']).to include('spread')
+    end
+
+    it 'still filters normally on a known filter_not key' do
+      get_json('/api/v1/species', filter_not: { average_height_cm: 'null' })
+
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'rejects an unknown filter key with a 400 naming the key' do
+      body = get_json('/api/v1/species', filter: { not_a_real_field: 'x' })
+
+      expect(response).to have_http_status(:bad_request)
+      expect(body['message']).to include('not_a_real_field')
+    end
+
+    it 'still filters normally on a known filter key' do
+      get_json('/api/v1/species', filter: { author: 'x' })
+
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'rejects an unknown order key with a 400 naming the key' do
+      body = get_json('/api/v1/species', order: { not_a_real_field: 'asc' })
+
+      expect(response).to have_http_status(:bad_request)
+      expect(body['message']).to include('not_a_real_field')
+    end
+
+    it 'still sorts normally on a known order key' do
+      get_json('/api/v1/species', order: { scientific_name: 'asc' })
+
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'rejects an unknown range key with a 400 naming the key' do
+      body = get_json('/api/v1/species', range: { not_a_real_field: '1,2' })
+
+      expect(response).to have_http_status(:bad_request)
+      expect(body['message']).to include('not_a_real_field')
+    end
+
+    it 'still ranges normally on a known range key' do
+      get_json('/api/v1/species', range: { year: '1990,2000' })
+
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe 'GET /api/v1/plants' do
+    it 'rejects an unknown filter_not key with a 400 naming the key' do
+      body = get_json('/api/v1/plants', filter_not: { spread: 'null' })
+
+      expect(response).to have_http_status(:bad_request)
+      expect(body['message']).to include('spread')
+    end
+
+    it 'still filters normally on a known filter_not key' do
+      get_json('/api/v1/plants', filter_not: { average_height_cm: 'null' })
+
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'rejects an unknown filter key with a 400 naming the key' do
+      body = get_json('/api/v1/plants', filter: { not_a_real_field: 'x' })
+
+      expect(response).to have_http_status(:bad_request)
+      expect(body['message']).to include('not_a_real_field')
+    end
+
+    it 'still filters normally on a known filter key' do
+      get_json('/api/v1/plants', filter: { author: 'x' })
+
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'rejects an unknown order key with a 400 naming the key' do
+      body = get_json('/api/v1/plants', order: { not_a_real_field: 'asc' })
+
+      expect(response).to have_http_status(:bad_request)
+      expect(body['message']).to include('not_a_real_field')
+    end
+
+    it 'still sorts normally on a known order key' do
+      get_json('/api/v1/plants', order: { scientific_name: 'asc' })
+
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'rejects an unknown range key with a 400 naming the key' do
+      body = get_json('/api/v1/plants', range: { not_a_real_field: '1,2' })
+
+      expect(response).to have_http_status(:bad_request)
+      expect(body['message']).to include('not_a_real_field')
+    end
+
+    it 'still ranges normally on a known range key' do
+      get_json('/api/v1/plants', range: { year: '1990,2000' })
+
+      expect(response).to have_http_status(:success)
+    end
+  end
+end


### PR DESCRIPTION
Closes #205

## What

`apply_filters`, `apply_filters_not`, `apply_sort` and `apply_range` in `Api::ApiController` used to silently drop any `filter`/`filter_not`/`order`/`range` key not in the controller's allowed list via `permit`/`slice`. A typo'd filter (e.g. `filter_not[spread]`) was ignored and the API returned an unfiltered result with no indication anything was wrong.

They now raise `Api::ApiController::UnknownQueryKeyError`, rescued into a 400 naming the rejected key(s) and the valid keys for that param, via the existing `render_error` shape (`{ error: true, message: ... }`) already used for 401s. Behavior for valid keys is unchanged.

This is generic to `Api::ApiController`, so it also applies to families/genus/zones/record_corrections, not just species/plants.

## Testing

- New request specs in `spec/requests/api/v1/filter_validation_spec.rb` covering reject + unchanged-valid-key cases for filter/filter_not/order/range on both species and plants.
- `bundle exec rspec spec/controllers/api/v1/ spec/requests/api/v1/` — 524 examples, 0 failures.
- `bundle exec rubocop` — clean on changed files.
- `bundle exec brakeman` — 0 warnings.
- Full suite: 35 pre-existing failures in `spec/features/` and `spec/requests/web/` (Sprockets asset-pipeline error, unrelated to this change — pre-existing in this environment).

Touches: app/controllers/api/, spec/requests/