### PR TITLE
Dev environment hygiene: no real mail by default, honor $PORT, prune stale brakeman ignore

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,2 @@
-web: bin/rails server -p 3000
+web: bin/rails server -p ${PORT:-3232}
 js: yarn build --watch

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -101,16 +101,6 @@
       "note": "Interpolated identifiers come from frozen constant lists or DB integer ids, never from user input."
     },
     {
-      "warning_type": "Unmaintained Dependency",
-      "warning_code": 120,
-      "fingerprint": "d84924377155b41e094acae7404ec2e521629d86f97b0ff628e3d1b263f8101c",
-      "check_name": "EOLRails",
-      "message": "Support for Rails 7.0.10 ended on 2025-04-01",
-      "file": "Gemfile.lock",
-      "line": 407,
-      "note": "Rails 7.0 EOL acknowledged; staged upgrade to 7.1/7.2/8.0 is planned."
-    },
-    {
       "warning_type": "SQL Injection",
       "warning_code": 0,
       "fingerprint": "e06841b0d2b2ad77df107f0cc2cdae10dba0daefed83d198a833fe2546b15cf6",
@@ -131,6 +121,6 @@
       "note": "Management backoffice is admin-only (check_admin); admins editing user records is the feature."
     }
   ],
-  "updated": "2026-09-02",
+  "updated": "2026-09-03",
   "brakeman_version": "8.0.6"
 }

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -84,6 +84,12 @@ Rails.application.configure do
     }
 
     config.action_mailer.smtp_settings = mail_metadatas
+  else
+    # No real mail in development by default: mails are captured by the :test
+    # delivery method instead of being attempted for real. Set LOCAL_MAILER=true
+    # (see .env.local.example) for the rare case where sending is wanted.
+    config.action_mailer.delivery_method = :test
+    config.action_mailer.perform_deliveries = false
   end
 
   # Raises error for missing translations.


### PR DESCRIPTION
Closes #207

Three small dev-environment fixes bundled together per the issue (shared scope, no production behavior change):

1. **No real mail in development.** `config/environments/development.rb` now explicitly sets `delivery_method = :test` / `perform_deliveries = false` unless `LOCAL_MAILER=true` is set, so a console session or manual test can no longer email real users by default. The existing SMTP/`LOCAL_MAILER=true` override path is unchanged.
2. **Honor $PORT in Procfile.dev.** `bin/rails server -p ${PORT:-3232}` instead of a hardcoded `3000`, matching `.env` and avoiding collisions with other local services.
3. **Prune `config/brakeman.ignore`.** Removed the obsolete `EOLRails` (Rails 7.0.10) entry — the app is on Rails 8.0.5.1, so Brakeman flagged it as an obsolete ignore.

## Verification
- `bundle exec rails runner ''` in development no longer prints the mailer warning (verified with `LOCAL_MAILER` unset/false; verified the warning still appears and SMTP is used when `LOCAL_MAILER=true`).
- `Procfile.dev`'s shell expansion verified directly: honors $PORT when set, falls back to 3232 otherwise.
- `bundle exec brakeman`: 0 warnings, 0 obsolete ignore entries (was 1 obsolete before this change).
- `bundle exec rubocop`: 368 files inspected, no offenses.
- `bundle exec rspec`: 700 examples, 0 failures, 10 pending (pre-existing "not yet implemented" placeholders).

Touches: config/environments/development.rb, Procfile.dev, config/brakeman.ignore