### PR TITLE
CI hardening: coverage floor, scheduled dependency audit, README badges

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,39 @@
+name: Dependency audit
+
+on:
+  schedule:
+    - cron: '0 6 * * 1' # weekly, Monday 06:00 UTC
+  pull_request:
+    paths:
+      - Gemfile.lock
+      - yarn.lock
+
+jobs:
+  bundler-audit:
+    name: bundler-audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: Install bundler-audit
+        run: gem install bundler-audit
+      - name: Run bundler-audit
+        run: bundler-audit check --update
+
+  yarn-audit:
+    name: yarn audit
+    runs-on: ubuntu-latest
+    # Non-blocking to start: surfaces vulnerable JS deps without failing CI.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: lts/*
+          cache: yarn
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Run yarn audit
+        run: yarn audit --level high

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 [🌎 Website](https://trefle.io)  •  [🚀 Getting started](https://docs.trefle.io)  •  [📖 API Documentation](https://docs.trefle.io/reference)  •  [💡 Ideas and features](https://github.com/orgs/treflehq/projects/3)  •  [🐛 Issues](https://github.com/orgs/treflehq/projects/2)
 
+[![CI](https://github.com/treflehq/trefle-api/actions/workflows/ci.yml/badge.svg)](https://github.com/treflehq/trefle-api/actions/workflows/ci.yml) [![License: AGPL v3](https://img.shields.io/github/license/treflehq/trefle-api)](LICENSE.md) [![Latest release](https://img.shields.io/github/v/release/treflehq/trefle-api)](https://github.com/treflehq/trefle-api/releases)
+
 [![View performance data on Skylight](https://badges.skylight.io/status/nz7MAOv6K6ra.svg)](https://oss.skylight.io/app/applications/nz7MAOv6K6ra) [![View performance data on Skylight](https://badges.skylight.io/rpm/nz7MAOv6K6ra.svg)](https://oss.skylight.io/app/applications/nz7MAOv6K6ra) [![View performance data on Skylight](https://badges.skylight.io/problem/nz7MAOv6K6ra.svg)](https://oss.skylight.io/app/applications/nz7MAOv6K6ra) [![View performance data on Skylight](https://badges.skylight.io/typical/nz7MAOv6K6ra.svg)](https://oss.skylight.io/app/applications/nz7MAOv6K6ra)
 
 ## What is Trefle?

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,9 @@ SimpleCov.start 'rails' do
   # Private crawler code lives outside this repository
   add_filter 'lib/crawlers'
   add_filter 'app/workers/crawlers'
+
+  # Floor is raised as coverage improves (see #204) — never lower it here.
+  minimum_coverage 65
 end
 
 require 'database_cleaner'


### PR DESCRIPTION
Closes #208

- SimpleCov: enforce `minimum_coverage 65` so a PR dropping line coverage below the current baseline (65.9%) fails the RSpec job. The floor is raised as #204 progresses, not here.
- New `.github/workflows/dependency-audit.yml`: weekly scheduled + on-PR (paths: `Gemfile.lock`, `yarn.lock`) job running `bundler-audit` (blocking) and `yarn audit --level high` (non-blocking, `continue-on-error`) so vulnerable dependencies surface visibly in Actions instead of silently between Dependabot PRs.
- README: added CI status, license, and latest-release badges, no other content changes.

Verification:
- Full RSpec suite: 700 examples, 0 failures, 10 pending (pre-existing), coverage 65.94% — matches the issue's stated baseline.
- RuboCop: 368 files inspected, no offenses.
- Brakeman: 0 warnings, 0 errors.
- Smoke-tested `bundler-audit check --update` and `yarn audit --level high` directly against this repo's lockfiles to confirm the commands are correct for this project's toolchain (classic Yarn 1 lockfile format) before wiring them into the workflow.

Note: bundler-audit currently reports real vulnerabilities in this repo's Gemfile.lock (rack, rails-html-sanitizer, websocket-driver) and yarn audit reports several in yarn.lock. That's expected — this PR's job is to make that visible, not to fix them; the scheduled job will run red until those are bumped in follow-up PRs.

Touches: spec/spec_helper.rb, .github/workflows/, README.md