### PR TITLE
Bump sentry-ruby / sentry-rails 6.x to 7.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,8 +67,8 @@ gem 'pghero'
 gem 'pg_query', '>= 0.9.0'
 gem 'rack-attack', '~> 6.6.1'
 
-gem "sentry-ruby"
-gem "sentry-rails"
+gem "sentry-ruby", "~> 7.0"
+gem "sentry-rails", "~> 7.0"
 gem "skylight"
 
 # Sidekiq

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,7 @@ GEM
     bcrypt (3.1.22)
     benchmark (0.4.1)
     benchmark-ips (2.14.0)
-    bigdecimal (4.0.1)
+    bigdecimal (4.1.2)
     bindex (0.8.1)
     bootsnap (1.23.0)
       msgpack (~> 1.2)
@@ -110,7 +110,7 @@ GEM
       numerizer (~> 0.1.1)
     coderay (1.1.3)
     colorize (1.1.0)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.8)
     connection_pool (2.5.5)
     counter_culture (2.9.0)
       activerecord (>= 4.2)
@@ -120,7 +120,7 @@ GEM
     crack (1.0.1)
       bigdecimal
       rexml
-    crass (1.0.6)
+    crass (1.0.7)
     cronex (0.15.0)
       tzinfo
       unicode (>= 0.4.4.5)
@@ -238,14 +238,14 @@ GEM
       csv
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
-    i18n (1.14.8)
+    i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     interactor (3.2.0)
       ostruct
     interactor-rails (2.3.0)
       interactor (~> 3.0)
       railties (>= 7.0)
-    io-console (0.8.2)
+    io-console (0.9.2)
     irb (1.18.0)
       pp (>= 0.6.0)
       prism (>= 1.3.0)
@@ -265,7 +265,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     logger (1.7.0)
-    loofah (2.25.1)
+    loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.9.1)
@@ -288,7 +288,7 @@ GEM
     method_source (1.1.0)
     mini_histogram (0.3.1)
     mini_mime (1.1.5)
-    minitest (6.0.2)
+    minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
     msgpack (1.8.0)
@@ -308,21 +308,21 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
-    nokogiri (1.19.1-aarch64-linux-gnu)
+    nokogiri (1.19.4-aarch64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.19.1-aarch64-linux-musl)
+    nokogiri (1.19.4-aarch64-linux-musl)
       racc (~> 1.4)
-    nokogiri (1.19.1-arm-linux-gnu)
+    nokogiri (1.19.4-arm-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.19.1-arm-linux-musl)
+    nokogiri (1.19.4-arm-linux-musl)
       racc (~> 1.4)
-    nokogiri (1.19.1-arm64-darwin)
+    nokogiri (1.19.4-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.19.1-x86_64-darwin)
+    nokogiri (1.19.4-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.19.1-x86_64-linux-gnu)
+    nokogiri (1.19.4-x86_64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.19.1-x86_64-linux-musl)
+    nokogiri (1.19.4-x86_64-linux-musl)
       racc (~> 1.4)
     numerizer (0.1.1)
     oauth2 (2.0.18)
@@ -388,7 +388,7 @@ GEM
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)
-    rack (2.2.22)
+    rack (2.2.24)
     rack-attack (6.6.1)
       rack (>= 1.0, < 3)
     rack-protection (3.2.0)
@@ -423,8 +423,8 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.7.0)
-      loofah (~> 2.25)
+    rails-html-sanitizer (1.7.1)
+      loofah (~> 2.25, >= 2.25.2)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     railties (8.0.5.1)
       actionpack (= 8.0.5.1)
@@ -436,7 +436,7 @@ GEM
       tsort (>= 0.2)
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
-    rake (13.3.1)
+    rake (13.4.2)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
@@ -455,7 +455,7 @@ GEM
     redis-client (0.27.0)
       connection_pool
     regexp_parser (2.11.3)
-    reline (0.6.3)
+    reline (0.7.0)
       io-console (~> 0.5)
     responders (3.2.0)
       actionpack (>= 7.0)
@@ -536,10 +536,10 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
-    sentry-rails (6.5.0)
+    sentry-rails (7.0.0)
       railties (>= 5.2.0)
-      sentry-ruby (~> 6.5.0)
-    sentry-ruby (6.5.0)
+      sentry-ruby (~> 7.0.0)
+    sentry-ruby (7.0.0)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
       logger
@@ -618,7 +618,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.7.5)
+    zeitwerk (2.8.3)
 
 PLATFORMS
   aarch64-linux
@@ -697,8 +697,8 @@ DEPENDENCIES
   searchkick
   seed_dump
   selenium-webdriver
-  sentry-rails
-  sentry-ruby
+  sentry-rails (~> 7.0)
+  sentry-ruby (~> 7.0)
   sidekiq (~> 7.3)
   sidekiq-cron (>= 0.6.3)
   sidekiq-limit_fetch


### PR DESCRIPTION
Closes #210

Bumps `sentry-ruby` and `sentry-rails` from 6.5.0 to ~> 7.0.

Reviewed the [7.0 upgrade guide](https://github.com/getsentry/sentry-ruby/blob/master/CHANGELOG.md): the breaking changes (logs/metrics enabled by default, `send_default_pii` -> `data_collection` migration, OTLP exporter defaults) don't touch our `config/initializers/sentry.rb`, which only sets `dsn`, `breadcrumbs_logger` and `traces_sample_rate`. No initializer changes were needed. `Sentry.set_user`/`set_tags` calls in the controllers are manual and unaffected by the PII default change.

Acceptance criteria:
- [x] Full RSpec suite green (700 examples, 0 failures), RuboCop and Brakeman clean (0 warnings).
- [x] App boots in development; verified with `bin/rails runner` + a manual `Sentry.capture_message` smoke test (no delivery assertion, DSN unset locally).

Touches: Gemfile, Gemfile.lock