### PR TITLE
Use the modern cache pool syntax for the memcached store

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -51,7 +51,7 @@ Rails.application.configure do
   config.log_tags = [ :request_id ]
 
   # Use a different cache store in production.
-  config.cache_store = :mem_cache_store, ENV['MEMCACHED_URL'], { pool_size: 5 }
+  config.cache_store = :mem_cache_store, ENV['MEMCACHED_URL'], { pool: { size: 5 } }
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque


### PR DESCRIPTION
The production cache store still used the pre-7.1 `pool_size: 5` option. Rails 8 expects `pool: { size: 5 }`; this keeps the 5-connection pool with the supported syntax.

Verified locally: the store instantiates with these arguments (dalli + connection_pool), full suite green (700 examples, 0 failures), RuboCop and Brakeman clean.

Part of #222.