### PR TITLE
Explore images: real <img> tags, sized variants, lazy loading, alt text, empty-state placeholder

### DIFF
--- a/app/assets/javascripts/sections/_explore.scss
+++ b/app/assets/javascripts/sections/_explore.scss
@@ -169,12 +169,9 @@
     min-height: 150px;
     height: 100%;
     display: flex;
-    background-color: #ccc;
     margin: 10px 0;
     border-radius: 3px;
-    background-position: center;
-    background-repeat: no-repeat;
-    background-size: cover;
+    overflow: hidden;
   }
 
   main {
@@ -186,6 +183,32 @@
     p {
       color: #6f6f6f
     }
+  }
+}
+
+// Real <img>/placeholder rendered by SpeciesPhotoHelper#species_photo_tag, replacing
+// the background-image divs the cards and headers used to rely on (see issue #232).
+.species-grid-item-photo,
+.species-correction-image-photo {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center;
+  display: block;
+}
+
+.species-grid-item-photo--empty,
+.species-correction-image-photo--empty {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: #e3f3e6;
+
+  i {
+    color: #3ca35a;
+    font-size: 2rem;
   }
 }
 
@@ -259,22 +282,22 @@
   .species-correction-image {
     height: 100%;
     display: flex;
-    background-color: #ccc;
     margin: 10px 0;
     border-radius: 3px;
-    background-position: center;
-    background-repeat: no-repeat;
+    overflow: hidden;
   }
 
   .species-side-image {
     min-height: 300px;
+    background-color: #ccc;
+    background-position: center;
+    background-repeat: no-repeat;
     background-size: cover;
   }
 
   .species-correction-image {
     min-height: 100px;
     margin: 0;
-    background-size: cover;
   }
 
   .done-footer {

--- a/app/controllers/explore/genus_controller.rb
+++ b/app/controllers/explore/genus_controller.rb
@@ -17,7 +17,10 @@ class Explore::GenusController < Explore::ExploreController
     @page_description = "#{@genus.name} is a genus of the #{@genus.family&.name} family"
     @page_keywords    = [@genus.name, 'genus', 'plant', 'explore'].compact.join(', ')
 
-    @species = @genus.species.where.not(main_image_url: nil).order(wiki_score: :desc).first
+    # Picking the best-ranked species regardless of whether it has a photo lets the
+    # header fall back to the empty-state placeholder instead of crashing (or silently
+    # hiding the genus header) when none of the genus' species has one.
+    @species = @genus.species.order(wiki_score: :desc).first
     set_meta_tags(
       image_src: @species&.main_image_url,
       og: {

--- a/app/helpers/species_photo_helper.rb
+++ b/app/helpers/species_photo_helper.rb
@@ -1,0 +1,48 @@
+# Renders species photos as real <img> tags (lazy, sized, with alt text) instead of
+# the CSS background-image divs the explore views used to rely on, and supplies a
+# tinted placeholder for species that have no photo at all. See issue #232.
+module SpeciesPhotoHelper
+  PLANTNET_ORIGINAL_SEGMENT = '/image/o/'.freeze
+
+  DEFAULT_WIDTH = 400
+  DEFAULT_HEIGHT = 300
+
+  # Swaps a plantnet original-size URL (bs.plantnet.org/image/o/...) for the given
+  # size variant (plantnet supports o/m/s). Non-plantnet URLs (legacy cloudfront
+  # ones, for instance) are returned untouched, since we don't know their variants.
+  def species_photo_src(url, size: :m)
+    return url if url.blank?
+
+    url.sub(PLANTNET_ORIGINAL_SEGMENT, "/image/#{size}/")
+  end
+
+  def species_photo_alt(species)
+    return '' unless species
+
+    if species.common_name.present?
+      "#{species.scientific_name} (#{species.common_name})"
+    else
+      species.scientific_name.to_s
+    end
+  end
+
+  # Renders a lazy-loaded, medium-sized <img> for the species' main photo, or a
+  # tinted placeholder with a leaf glyph when the species has no photo.
+  def species_photo_tag(species, css_class:, size: :m, width: DEFAULT_WIDTH, height: DEFAULT_HEIGHT)
+    url = species&.main_image_url
+
+    if url.present?
+      image_tag species_photo_src(url, size: size),
+                class: css_class,
+                alt: species_photo_alt(species),
+                loading: 'lazy',
+                decoding: 'async',
+                width: width,
+                height: height
+    else
+      content_tag :div, class: "#{css_class} #{css_class}--empty" do
+        content_tag :i, '', class: 'fad fa-leaf', 'aria-hidden': 'true'
+      end
+    end
+  end
+end

--- a/app/views/explore/genus/_genus_header.html.erb
+++ b/app/views/explore/genus/_genus_header.html.erb
@@ -1,13 +1,15 @@
 <nav class="breadcrumb" aria-label="breadcrumbs">
     <ul>
-      <li><a href="#"><%= species.family_name %></a></li>
+      <li><a href="#"><%= species&.family_name %></a></li>
       <li class="is-active"><a href="#" aria-current="page"><%= genus.name %></a></li>
     </ul>
   </nav>
 
   <div class="columns">
     <div class="column is-3">
-      <aside class="species-correction-image" style="background-image: url(<%= species.main_image_url %>)"></aside>
+      <aside class="species-correction-image">
+        <%= species_photo_tag(species, css_class: 'species-correction-image-photo', width: 300, height: 300) %>
+      </aside>
     </div>
     <div class="column is-9">
           <div class="container">

--- a/app/views/explore/record_corrections/_correction_header.html.erb
+++ b/app/views/explore/record_corrections/_correction_header.html.erb
@@ -11,7 +11,9 @@
 
   <div class="columns">
     <div class="column is-3">
-      <aside class="species-correction-image" style="background-image: url(<%= species.main_image_url %>)"></aside>
+      <aside class="species-correction-image">
+        <%= species_photo_tag(species, css_class: 'species-correction-image-photo', width: 300, height: 300) %>
+      </aside>
     </div>
     <div class="column is-9">
           <div class="section content">

--- a/app/views/explore/species/_species_header.html.erb
+++ b/app/views/explore/species/_species_header.html.erb
@@ -8,7 +8,9 @@
 
   <div class="columns">
     <div class="column is-3">
-      <aside class="species-correction-image" style="background-image: url(<%= species.main_image_url %>)"></aside>
+      <aside class="species-correction-image">
+        <%= species_photo_tag(species, css_class: 'species-correction-image-photo', width: 300, height: 300) %>
+      </aside>
     </div>
     <div class="column is-9">
           <div class="container">

--- a/app/views/explore/species/_species_item.html.erb
+++ b/app/views/explore/species/_species_item.html.erb
@@ -1,5 +1,5 @@
 <%= link_to explore_species_path(species), class: 'species-grid-item' do %>
-  <aside style="background-image: url(<%= species.main_image_url %>)"></aside>
+  <aside><%= species_photo_tag(species, css_class: 'species-grid-item-photo') %></aside>
   <main>
     <h2 class="title is-5">
 

--- a/spec/helpers/species_photo_helper_spec.rb
+++ b/spec/helpers/species_photo_helper_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+RSpec.describe SpeciesPhotoHelper, type: :helper do
+  describe '#species_photo_src' do
+    it 'swaps the plantnet original-size segment for the requested size' do
+      url = 'https://bs.plantnet.org/image/o/abc123.jpg'
+
+      expect(helper.species_photo_src(url)).to eq('https://bs.plantnet.org/image/m/abc123.jpg')
+    end
+
+    it 'honors an explicit size' do
+      url = 'https://bs.plantnet.org/image/o/abc123.jpg'
+
+      expect(helper.species_photo_src(url, size: :s)).to eq('https://bs.plantnet.org/image/s/abc123.jpg')
+    end
+
+    it 'returns non-plantnet urls untouched' do
+      url = 'https://cdn.example.com/foo.jpg'
+
+      expect(helper.species_photo_src(url)).to eq(url)
+    end
+
+    it 'returns blank input as-is' do
+      expect(helper.species_photo_src(nil)).to be_nil
+      expect(helper.species_photo_src('')).to eq('')
+    end
+  end
+
+  describe '#species_photo_alt' do
+    it 'combines scientific and common name' do
+      species = build(:species, scientific_name: 'Abies alba', common_name: 'Silver fir')
+
+      expect(helper.species_photo_alt(species)).to eq('Abies alba (Silver fir)')
+    end
+
+    it 'falls back to the scientific name alone when there is no common name' do
+      species = build(:species, scientific_name: 'Abies alba', common_name: nil)
+
+      expect(helper.species_photo_alt(species)).to eq('Abies alba')
+    end
+
+    it 'returns an empty string for a nil species' do
+      expect(helper.species_photo_alt(nil)).to eq('')
+    end
+  end
+
+  describe '#species_photo_tag' do
+    it 'renders a lazy-loaded img with a medium src and meaningful alt text when a photo exists' do
+      species = build(:species,
+                      scientific_name: 'Abies alba',
+                      common_name: 'Silver fir',
+                      main_image_url: 'https://bs.plantnet.org/image/o/abc123.jpg')
+
+      node = Nokogiri::HTML.fragment(helper.species_photo_tag(species, css_class: 'species-grid-item-photo')).at_css('img')
+
+      expect(node).not_to be_nil
+      expect(node['src']).to eq('https://bs.plantnet.org/image/m/abc123.jpg')
+      expect(node['alt']).to eq('Abies alba (Silver fir)')
+      expect(node['loading']).to eq('lazy')
+      expect(node['decoding']).to eq('async')
+      expect(node['class']).to eq('species-grid-item-photo')
+      expect(node['width']).to be_present
+      expect(node['height']).to be_present
+    end
+
+    it 'renders a placeholder with a leaf glyph when the species has no photo' do
+      species = build(:species, scientific_name: 'Abies alba', common_name: 'Silver fir', main_image_url: nil)
+
+      fragment = Nokogiri::HTML.fragment(helper.species_photo_tag(species, css_class: 'species-grid-item-photo'))
+
+      expect(fragment.at_css('img')).to be_nil
+      placeholder = fragment.at_css('div.species-grid-item-photo.species-grid-item-photo--empty')
+      expect(placeholder).not_to be_nil
+      expect(placeholder.at_css('i.fa-leaf')).not_to be_nil
+    end
+  end
+end

--- a/spec/requests/web/explore_spec.rb
+++ b/spec/requests/web/explore_spec.rb
@@ -13,6 +13,34 @@ RSpec.describe 'Explore pages', type: :request do
       get explore_path, params: { search: 'Abies' }
       expect(response).to have_http_status(:ok)
     end
+
+    it 'renders a tinted leaf placeholder for species without a photo, not a background-image div' do
+      species = Species.order(wiki_score: :desc).first
+      species.update!(main_image_url: nil)
+
+      get explore_path
+      expect(response.body).not_to include('background-image')
+
+      card = Nokogiri::HTML.fragment(response.body).at_css("a[href=\"#{explore_species_path(species)}\"]")
+      expect(card.at_css('div.species-grid-item-photo--empty i.fa-leaf')).not_to be_nil
+    end
+
+    it 'renders a real, lazy-loaded, sized <img> for species that have a photo' do
+      species = Species.order(wiki_score: :desc).first
+      species.update!(main_image_url: 'https://bs.plantnet.org/image/o/abc123.jpg')
+
+      get explore_path
+      card = Nokogiri::HTML.fragment(response.body).at_css("a[href=\"#{explore_species_path(species)}\"]")
+      img = card.at_css('img')
+
+      expect(img['src']).to eq('https://bs.plantnet.org/image/m/abc123.jpg')
+      expect(img['loading']).to eq('lazy')
+      expect(img['decoding']).to eq('async')
+      expected_alt = species.common_name.present? ? "#{species.scientific_name} (#{species.common_name})" : species.scientific_name
+      expect(img['alt']).to eq(expected_alt)
+      expect(img['width']).to be_present
+      expect(img['height']).to be_present
+    end
   end
 
   describe 'GET /explore/species/:id' do
@@ -21,6 +49,19 @@ RSpec.describe 'Explore pages', type: :request do
       get explore_species_path(species)
       expect(response).to have_http_status(:ok)
       expect(response.body).to include('Abies alba')
+    end
+
+    it 'renders a real <img> header photo for a species that has one, with no background-image left' do
+      species = Species.friendly.find('abies-alba')
+      species.update!(main_image_url: 'https://bs.plantnet.org/image/o/abc123.jpg')
+
+      get explore_species_path(species)
+      expect(response.body).not_to include('background-image')
+
+      img = Nokogiri::HTML.fragment(response.body).at_css('.species-correction-image img')
+      expect(img['src']).to eq('https://bs.plantnet.org/image/m/abc123.jpg')
+      expect(img['loading']).to eq('lazy')
+      expect(img['alt']).to be_present
     end
   end
 
@@ -35,6 +76,16 @@ RSpec.describe 'Explore pages', type: :request do
       get explore_genus_path(genus)
       expect(response).to have_http_status(:ok)
       expect(response.body).to include('Abies')
+    end
+
+    it 'renders a leaf placeholder in the genus header when none of its species has a photo' do
+      genus = Genus.find_by!(name: 'Abies')
+      genus.species.update_all(main_image_url: nil)
+
+      get explore_genus_path(genus)
+
+      placeholder = Nokogiri::HTML.fragment(response.body).at_css('.species-correction-image .species-correction-image-photo--empty i.fa-leaf')
+      expect(placeholder).not_to be_nil
     end
   end
 


### PR DESCRIPTION
Closes #232

## What

Explore index cards and the species/genus/correction headers rendered
photos as CSS `background-image` divs pointing at full-size plantnet
(`/image/o/...`) or cloudfront sources: no lazy loading, no alt text,
and a bare grey box for species without a photo.

- New `SpeciesPhotoHelper#species_photo_tag` renders a real `<img>`
  with a medium-size plantnet variant (`/image/m/` instead of
  `/image/o/`; non-plantnet URLs are left untouched since their size
  scheme isn't known), `loading="lazy"`, `decoding="async"`, explicit
  `width`/`height`, and `alt` built from scientific + common name.
- Species without a photo now get a tinted placeholder (leaf glyph)
  instead of a grey rectangle.
- Applied to: explore species grid cards, species show header, genus
  show header, and the record-correction header (they all shared the
  same background-image markup/CSS, so all three had to move together).
- `Explore::GenusController#show` now picks the genus' best-ranked
  species regardless of whether it has a photo (previously it only
  considered species *with* a photo, so a genus where none of its
  species had one would 500 on the header partial). This also makes the
  new empty-state placeholder reachable on genus pages.

## Scope note

The species show page has an empty, unimplemented "Images" gallery
section (`id="images"`) that renders no photos today — building a real
multi-photo gallery there is new feature work beyond swapping existing
background-image divs for `<img>` tags, so it's left untouched. The
species header photo is the only existing "gallery" rendering today and
is covered.

## Testing

- New `spec/helpers/species_photo_helper_spec.rb`: URL size-variant
  mapping, alt text, and the img/placeholder branches.
- Extended `spec/requests/web/explore_spec.rb`: asserts real `<img>`
  markup (lazy, sized, alt) and the leaf placeholder on the explore
  index, species show, and genus show pages, and confirms no
  `background-image` remains in any of their responses.
- `bundle exec rspec`: 729 examples, 0 failures (10 pre-existing
  pending specs, unrelated).
- `bundle exec rubocop`: 0 offenses.
- `bundle exec brakeman`: 0 warnings.

Touches: app/views/explore, app/helpers, app/assets/javascripts/sections, app/controllers/explore/genus_controller.rb