### PR TITLE
Expose RateLimit-* headers on every /api response

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,10 +1,29 @@
 class Rack::Attack
 
+  REQUEST_PER_IP_THROTTLE = 'request per ip'.freeze
+
   def self.token(req)
     [
       req.env['HTTP_AUTHORIZATION'].to_s.downcase.gsub(/bearer /, ''),
       req.params['token'].to_s.downcase.gsub(/\s+/, '')
     ].reject(&:blank?).first
+  end
+
+  # Builds the RateLimit-* headers (draft IETF RateLimit-Limit /
+  # RateLimit-Remaining / RateLimit-Reset convention -- documented alongside
+  # the getting-started guide's rate limiting section). Shared by the
+  # throttled_responder below (429s) and by RateLimitHeadersMiddleware
+  # (every other /api response).
+  def self.rate_limit_headers(match_data)
+    now = match_data[:epoch_time]
+    reset_at = now + (match_data[:period] - now % match_data[:period])
+    remaining = [match_data[:limit] - match_data[:count], 0].max
+
+    {
+      'RateLimit-Limit' => match_data[:limit].to_s,
+      'RateLimit-Remaining' => remaining.to_s,
+      'RateLimit-Reset' => reset_at.to_s
+    }
   end
 end
 
@@ -16,7 +35,7 @@ end
 limit_proc = proc { |req| Rack::Attack.token(req)&.starts_with?('spo-') ? 600 : 60 }
 
 
-Rack::Attack.throttle('request per ip', limit: limit_proc, period: 60) do |req|
+Rack::Attack.throttle(Rack::Attack::REQUEST_PER_IP_THROTTLE, limit: limit_proc, period: 60) do |req|
   [req.ip, Rack::Attack.token(req)].join('-') if req.path.starts_with?('/api')
 end
 
@@ -26,15 +45,9 @@ Rack::Attack.throttled_response_retry_after_header = true
 
 Rack::Attack.throttled_responder = lambda do |request|
   match_data = request.env['rack.attack.match_data']
-  now = match_data[:epoch_time]
   is_sponsor = Rack::Attack.token(request)&.starts_with?('spo-')
 
-  headers = {
-    'Content-Type' => 'application/json',
-    'RateLimit-Limit' => match_data[:limit].to_s,
-    'RateLimit-Remaining' => '0',
-    'RateLimit-Reset' => (now + (match_data[:period] - now % match_data[:period])).to_s
-  }
+  headers = { 'Content-Type' => 'application/json' }.merge(Rack::Attack.rate_limit_headers(match_data))
 
   [429, headers, [
     {
@@ -43,3 +56,33 @@ Rack::Attack.throttled_responder = lambda do |request|
     }.to_json]
   ]
 end
+
+# Surfaces the same RateLimit-* headers on every other /api response, not
+# just the throttled ones, so well-behaved clients can self-regulate before
+# hitting a 429. Rack::Attack annotates env['rack.attack.throttle_data'] for
+# every request it evaluates against a throttle rule, whether or not that
+# request ends up throttled -- this middleware reads that back.
+#
+# Defined inline (rather than under lib/, which is eager_load_paths-only
+# here) because config/initializers runs before Zeitwerk's main autoloader
+# is set up; an autoloadable constant referenced this early raises
+# NameError.
+class RateLimitHeadersMiddleware
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    status, headers, body = @app.call(env)
+
+    match_data = env.dig('rack.attack.throttle_data', Rack::Attack::REQUEST_PER_IP_THROTTLE)
+    headers.merge!(Rack::Attack.rate_limit_headers(match_data)) if match_data
+
+    [status, headers, body]
+  end
+end
+
+# `unshift` so this always wraps Rack::Attack (and sees its 429s),
+# regardless of whether this initializer or rack-attack's own railtie
+# ("rack-attack.middleware") runs first.
+Rails.application.config.middleware.unshift(RateLimitHeadersMiddleware)

--- a/spec/requests/api/v1/rate_limit_headers_spec.rb
+++ b/spec/requests/api/v1/rate_limit_headers_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe 'Rate limit headers', type: :request do
+
+  # Rack::Attack's Redis-backed counters survive across examples (they're
+  # not part of the DB transaction rollback), so every example needs a
+  # clean slate to get predictable Remaining/Reset values.
+  before { Rack::Attack.cache.reset! }
+  after { Rack::Attack.cache.reset! }
+
+  it 'carries RateLimit-* headers on a normal /api/v1 response' do
+    get '/api/v1/'
+
+    expect(response).to have_http_status(:ok)
+    expect(response.headers['RateLimit-Limit']).to eq('60')
+    expect(response.headers['RateLimit-Remaining']).to eq('59')
+    expect(response.headers['RateLimit-Reset'].to_i).to be > Time.now.to_i
+  end
+
+  it 'decrements RateLimit-Remaining as requests come in' do
+    get '/api/v1/'
+    get '/api/v1/'
+
+    expect(response.headers['RateLimit-Remaining']).to eq('58')
+  end
+
+  it 'carries RateLimit-* headers on the 429 once the limit is exceeded' do
+    60.times { get '/api/v1/' }
+    get '/api/v1/'
+
+    expect(response).to have_http_status(:too_many_requests)
+    expect(response.headers['RateLimit-Limit']).to eq('60')
+    expect(response.headers['RateLimit-Remaining']).to eq('0')
+    expect(response.headers['RateLimit-Reset'].to_i).to be > Time.now.to_i
+  end
+
+end


### PR DESCRIPTION
Closes #209.

## What

rack-attack throttles `/api` (60 req/min baseline, 600/min for sponsor tokens) but only added `RateLimit-Limit` / `RateLimit-Remaining` / `RateLimit-Reset` headers to the 429 responses it generated when blocking a request. Well-behaved clients had no way to see how close they were to the limit before getting cut off.

- Extracted the header-building logic (already used by `throttled_responder`) into `Rack::Attack.rate_limit_headers`.
- Added `RateLimitHeadersMiddleware`, a small Rack middleware wrapping the whole stack (`unshift`, so it always sees Rack::Attack's 429s too) that reads rack-attack's `env['rack.attack.throttle_data']` -- set on every /api request it evaluates against the throttle, whether or not that request is actually throttled -- and attaches the same three headers to every response.
- No change to the throttle configuration itself (still 60/min baseline, 600/min for `spo-` sponsor tokens).

Defined the middleware inline in the initializer rather than under `lib/` -- referencing an autoloadable `lib/` constant directly inside `config/initializers` raises `NameError`, since Zeitwerk's main autoloader isn't set up yet at that point in boot.

Also updated the *Rate limiting* section of the getting-started guide in `treflehq/documentation` (not pushed yet -- that repo currently has a large amount of unrelated pre-existing local changes, so I left mine uncommitted there rather than mixing them into a commit; flagging separately) to document the three headers and correct the stated limit (120/min in the doc vs. the actual 60/min in code).

## Testing

- New request spec `spec/requests/api/v1/rate_limit_headers_spec.rb`: asserts the three headers on a normal 200 response, that `RateLimit-Remaining` decrements across requests, and that all three headers are present and consistent on the 429 once the limit is exceeded.
- `bundle exec rspec spec/requests/api`: 83 examples, 0 failures.
- `bundle exec rubocop`: 370 files inspected, no offenses.
- Pre-existing, unrelated: `spec/requests/web/{home,explore,management}_spec.rb` fail with 500s on this baseline (`master` @ 61ca485) independent of this change -- confirmed by stashing and re-running.

Touches: config/initializers/rack_attack.rb, spec/requests/api/v1