### PR TITLE
Build the JS bundles before assets:precompile in the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,12 @@ RUN mkdir -p /app/tmp/pids && \
   chmod -R 777 /app/tmp && \
   chmod 777 /app/bin/post-start
 
+# Build the JS bundles BEFORE assets:precompile: sprockets indexes
+# app/assets/builds when the app boots, so the files must already exist
+# (running yarn build through the precompile enhancement leaves them out
+# of the sprockets manifest).
+RUN yarn build
+
 # SECRET_KEY_BASE_DUMMY lets the app boot for precompilation without the real
 # production secret, which is only injected at runtime.
 RUN SECRET_KEY_BASE_DUMMY=1 bundle exec rails assets:precompile --trace --verbose


### PR DESCRIPTION
The v2.0.1 image shipped without its main assets: every web page 500ed with `The asset "application.css" is not present in the asset pipeline` (observed on the canary deployment; API endpoints were fine).

Root cause: `assets:precompile` boots the app first, and sprockets indexes `app/assets/builds` at that point — before the jsbundling enhancement runs `yarn build` in the same rake invocation. The bundles land on disk but never enter the sprockets manifest, so the image had `app/assets/builds/application.css` present but nothing in `public/assets`.

Fix: run `yarn build` in its own image layer before the precompile step.

Verified by building the image locally: `public/assets` now contains the fingerprinted `application.css/js`, `codesandbox.js`, `home.js` (46 entries), and the canary reproduction is explained end to end.

Part of #222.