### PR TITLE
Data quality foundations: traits contract, provenance facts, source arbitration

### DIFF
--- a/app/controllers/api/v1/species_controller.rb
+++ b/app/controllers/api/v1/species_controller.rb
@@ -195,6 +195,18 @@ class Api::V1::SpeciesController < Api::ApiController
     )
   end
 
+  # Provenance of the species trait values: one row per (attribute, source)
+  # claim, including superseded and rejected ones (transparency)
+  def facts
+    @resource = Species.friendly.find(params[:id])
+    facts = @resource.species_facts.order(:attribute_name, :source, :id)
+
+    render json: Panko::Response.new(
+      data: Panko::ArraySerializer.new(facts, each_serializer: SpeciesFactSerializer).to_a,
+      meta: { total: facts.length }
+    )
+  end
+
   # Search on database
   # @TODO @deprecated
   def full_search

--- a/app/controllers/management/data_quality_controller.rb
+++ b/app/controllers/management/data_quality_controller.rb
@@ -1,0 +1,25 @@
+# Data quality dashboard: fill rates per field, trend over snapshots,
+# source conflicts and the prioritized work queue.
+class Management::DataQualityController < Management::ManagementController
+
+  def index
+    @latest_date = DataQualitySnapshot.maximum(:snapshot_on)
+
+    if @latest_date
+      snapshots = DataQualitySnapshot.on(@latest_date)
+      @field_rows = snapshots.global.where.not(attribute_name: nil).sort_by {|s| -(s.fill_rate || 0) }
+      @aggregate = snapshots.global.find_by(attribute_name: nil)
+      @rank_rows = snapshots.where(dimension: 'rank').order(species_count: :desc)
+      @source_rows = snapshots.where(dimension: 'source').order(species_count: :desc)
+    end
+
+    # Trend: aggregate row of each past snapshot
+    @history = DataQualitySnapshot.global.where(attribute_name: nil).order(:snapshot_on)
+
+    @priorities = Quality::Priorities.fetch(limit: 50)
+    @pending_plausibility_warnings = RecordCorrection.where(
+      warning_type: 'Checks::PlausibleValues', change_status: :pending
+    ).count
+  end
+
+end

--- a/app/interactors/corrections/validate_record_correction.rb
+++ b/app/interactors/corrections/validate_record_correction.rb
@@ -35,7 +35,7 @@ class Corrections::ValidateRecordCorrection
 
   # Validate ingester
   def check_ingestion!
-    context.ingester = Ingester::Species.new(context.correction, dry_run: true)
+    context.ingester = Ingester::Species.new(context.correction, dry_run: true, source: 'community')
     result = context.ingester.ingest!
     context.fail!(messages: result[:errors]) if result[:errors].any?
     context.fail!(messages: 'This correction don\'t seems to change anything') if result[:changes].empty?

--- a/app/models/data_quality_snapshot.rb
+++ b/app/models/data_quality_snapshot.rb
@@ -1,0 +1,18 @@
+# A dated data-quality measurement, written by `rake quality:snapshot`.
+# One row per (date, dimension, dimension_value, attribute); attribute_name is
+# nil for the aggregate row of a dimension.
+class DataQualitySnapshot < ApplicationRecord
+
+  validates :snapshot_on, presence: true
+  validates :dimension, presence: true
+
+  scope :on, ->(date) { where(snapshot_on: date) }
+  scope :global, -> { where(dimension: 'global') }
+
+  def fill_rate
+    return nil if species_count.zero?
+
+    (filled_count.to_f / species_count * 100).round(1)
+  end
+
+end

--- a/app/models/plant.rb
+++ b/app/models/plant.rb
@@ -68,19 +68,9 @@ class Plant < ApplicationRecord
 
   before_validation :update_completion_ratio!
 
+  # A plant is as complete as its main species (see Species#current_completion_percentage)
   def current_completion_percentage
-    return 0 unless main_species
-
-    ignored = [
-      *main_species.attributes.keys.filter {|e| e.starts_with?('z_leg_') },
-      'id', 'inserted_at', 'updated_at', 'created_at', 'complete_data'
-    ]
-
-    total = main_species.attributes.without(ignored).keys.count
-    complete = main_species.attributes.without(ignored).values.reject {|e| e.nil? || e.blank? || e == 0 }.count
-
-    Rails.logger.debug("[current_completion_percentage] #{complete} complete fields over #{total} fields")
-    ((complete.to_f / total.to_f).to_f * 100).to_i # rubocop:todo Style/FloatDivision
+    main_species&.current_completion_percentage || 0
   end
 
   def update_completion_ratio!

--- a/app/models/plant.rb
+++ b/app/models/plant.rb
@@ -108,7 +108,7 @@ class Plant < ApplicationRecord
   end
 
   def hybrids
-    species.subvar_rank
+    species.hybrid_rank
   end
 
   def forms
@@ -116,7 +116,7 @@ class Plant < ApplicationRecord
   end
 
   def subvarieties
-    species.hybrid_rank
+    species.subvar_rank
   end
 
 end

--- a/app/models/record_correction.rb
+++ b/app/models/record_correction.rb
@@ -73,7 +73,7 @@ class RecordCorrection < ApplicationRecord
       )
     else
       correction = JSON.parse(correction_json)
-      i = ::Ingester::Species.new(correction, species_id: record_id)
+      i = ::Ingester::Species.new(correction, species_id: record_id, source: 'community')
       res = i.ingest!
       if res[:valid]
         update(

--- a/app/models/species.rb
+++ b/app/models/species.rb
@@ -181,6 +181,7 @@ class Species < ApplicationRecord
   has_many :synonyms, as: :record, dependent: :destroy
   has_many :common_names, as: :record, dependent: :destroy
 
+  has_many :species_facts, dependent: :destroy
   has_many :species_trends, dependent: :destroy
   has_many :species_distributions, dependent: :destroy
   has_many :zones, through: :species_distributions
@@ -333,20 +334,18 @@ class Species < ApplicationRecord
     self.main_image_url = candidate if candidate
   end
 
+  # Percentage of filled trait fields, as defined by config/traits.yml:
+  # - only trait categories count (no cache/identity/USDA-legacy columns)
+  # - a field only counts when applicable (e.g. planting_* for edibles)
+  # - false is a filled value; 0 is only "empty" for bitmask/enum fields
   def current_completion_percentage
-    ignored = [
-      *attributes.keys.filter {|e| e.ends_with?('_count') },
-      *attributes.keys.filter {|e| e.ends_with?('_raw') },
-      'id', 'plant_id', 'genus_id', 'slug',
-      'inserted_at', 'updated_at', 'created_at', 'checked_at',
-      'token', 'full_token', 'complete_data', 'completion_ratio'
-    ]
+    fields = Traits.completion_fields.select {|f| Traits.applicable?(f, self) }
+    return 0 if fields.empty?
 
-    total = attributes.without(ignored).keys.count
-    complete = attributes.without(ignored).values.reject {|e| e.nil? || e.blank? || e == 0 }.count
+    complete = fields.count {|f| Traits.filled?(f, attributes[f]) }
 
-    Rails.logger.debug("[current_completion_percentage] #{complete} complete fields over #{total} fields")
-    ((complete.to_f / total.to_f).to_f * 100).to_i # rubocop:todo Style/FloatDivision
+    Rails.logger.debug("[current_completion_percentage] #{complete} complete fields over #{fields.length} fields")
+    ((complete.to_f / fields.length) * 100).to_i
   end
 
   def update_completion_ratio!

--- a/app/models/species_fact.rb
+++ b/app/models/species_fact.rb
@@ -1,0 +1,54 @@
+# A sourced value for one species attribute. The species columns are a
+# projection of the strongest active fact per attribute (see
+# Ingester::FactsRecorder); facts keep the full provenance trail.
+class SpeciesFact < ApplicationRecord
+
+  belongs_to :species
+
+  validates :attribute_name, presence: true
+  validates :source, presence: true
+
+  enum :evidence_type, {
+    reported: 0, # asserted by an external database, not independently measured
+    measured: 1, # backed by referenced measurements (e.g. TRY observations)
+    derived: 2,  # computed by us from primary data, documented method
+    inferred: 3  # imputed (e.g. from congeneric species)
+  }, suffix: true
+
+  # A losing claim stays "active" (it is still what that source says): the
+  # projected column value is simply the strongest active fact, and differing
+  # active facts on one attribute are the conflict list.
+  enum :status, {
+    active: 0,     # current claim from this source
+    superseded: 1, # replaced by a newer claim from the same source
+    rejected: 2    # failed plausibility validation, never projected
+  }, suffix: true
+
+  scope :for_attribute, ->(name) { where(attribute_name: name) }
+
+  # Records a value coming from a source. An :active fact supersedes this
+  # source's previous active fact for the attribute. Returns the created fact.
+  def self.record!(species:, attribute_name:, source:, value:, status: :active, **attrs)
+    if status.to_sym == :active
+      where(species: species, attribute_name: attribute_name, source: source, status: :active)
+        .find_each {|f| f.update!(status: :superseded) }
+    end
+
+    create!(
+      species: species,
+      attribute_name: attribute_name,
+      source: source,
+      value: value&.to_s,
+      value_numeric: value.is_a?(Numeric) ? value : nil,
+      unit: Traits.field(attribute_name)&.dig('unit'),
+      status: status,
+      **attrs
+    )
+  end
+
+  # Active facts disagreeing on the same attribute of the same species
+  def conflicting_facts
+    species.species_facts.active_status.for_attribute(attribute_name).where.not(id: id).where.not(value: value)
+  end
+
+end

--- a/app/serializers/species_fact_serializer.rb
+++ b/app/serializers/species_fact_serializer.rb
@@ -1,0 +1,10 @@
+# Provenance trail of a species attribute (see SpeciesFact):
+# which source claims which value, with what level of evidence.
+class SpeciesFactSerializer < BaseSerializer
+
+  attributes :attribute_name, :source, :value, :unit,
+             :evidence_type, :status, :notes,
+             :source_record_id, :source_url,
+             :n_observations, :observed_at, :updated_at
+
+end

--- a/app/views/management/data_quality/index.html.erb
+++ b/app/views/management/data_quality/index.html.erb
@@ -1,0 +1,148 @@
+<h1 class="title">Data quality</h1>
+
+<% if @latest_date.nil? %>
+  <div class="notification is-warning">
+    No snapshot yet. Run <code>rake quality:snapshot</code> (scheduled weekly via QualitySnapshotWorker).
+  </div>
+<% else %>
+
+  <div class="columns">
+    <div class="column">
+      <div class="box has-text-centered">
+        <p class="heading">Species</p>
+        <p class="title"><%= number_with_delimiter(@aggregate&.species_count) %></p>
+      </div>
+    </div>
+    <div class="column">
+      <div class="box has-text-centered">
+        <p class="heading">Avg completion</p>
+        <p class="title"><%= @aggregate&.details&.dig('avg_completion_ratio') || '—' %>%</p>
+      </div>
+    </div>
+    <div class="column">
+      <div class="box has-text-centered">
+        <p class="heading">Implausible values</p>
+        <p class="title"><%= number_with_delimiter(@aggregate&.implausible_count) %></p>
+      </div>
+    </div>
+    <div class="column">
+      <div class="box has-text-centered">
+        <p class="heading">Source conflicts</p>
+        <p class="title"><%= number_with_delimiter(@aggregate&.conflict_count) %></p>
+      </div>
+    </div>
+    <div class="column">
+      <div class="box has-text-centered">
+        <p class="heading">Pending plausibility warnings</p>
+        <p class="title"><%= number_with_delimiter(@pending_plausibility_warnings) %></p>
+      </div>
+    </div>
+  </div>
+
+  <p class="is-size-7 has-text-grey">Snapshot of <%= @latest_date %></p>
+
+  <h2 class="subtitle mt-5">Fill rate per field</h2>
+  <table class="table is-fullwidth is-striped is-narrow">
+    <thead>
+      <tr>
+        <th>Field</th>
+        <th style="width: 40%">Fill rate</th>
+        <th class="has-text-right">Filled</th>
+        <th class="has-text-right">Implausible</th>
+        <th class="has-text-right">Conflicts</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @field_rows.each do |row| %>
+        <tr>
+          <td><code><%= row.attribute_name %></code></td>
+          <td>
+            <progress class="progress is-small <%= (row.fill_rate || 0) > 50 ? 'is-success' : (row.fill_rate || 0) > 10 ? 'is-warning' : 'is-danger' %>"
+                      value="<%= row.fill_rate || 0 %>" max="100"><%= row.fill_rate %>%</progress>
+            <span class="is-size-7"><%= row.fill_rate %>%</span>
+          </td>
+          <td class="has-text-right"><%= number_with_delimiter(row.filled_count) %></td>
+          <td class="has-text-right <%= 'has-text-danger' if row.implausible_count.positive? %>"><%= number_with_delimiter(row.implausible_count) %></td>
+          <td class="has-text-right <%= 'has-text-danger' if row.conflict_count.positive? %>"><%= number_with_delimiter(row.conflict_count) %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <div class="columns mt-5">
+    <div class="column">
+      <h2 class="subtitle">By rank</h2>
+      <table class="table is-fullwidth is-narrow">
+        <thead><tr><th>Rank</th><th class="has-text-right">Species</th><th class="has-text-right">Avg completion</th></tr></thead>
+        <tbody>
+          <% @rank_rows.each do |row| %>
+            <tr>
+              <td><%= row.dimension_value %></td>
+              <td class="has-text-right"><%= number_with_delimiter(row.species_count) %></td>
+              <td class="has-text-right"><%= row.details&.dig('avg_completion_ratio') || '—' %>%</td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+    <div class="column">
+      <h2 class="subtitle">By source (facts)</h2>
+      <% if @source_rows.any? %>
+        <table class="table is-fullwidth is-narrow">
+          <thead><tr><th>Source</th><th class="has-text-right">Facts</th><th class="has-text-right">Active</th><th class="has-text-right">Rejected</th></tr></thead>
+          <tbody>
+            <% @source_rows.each do |row| %>
+              <tr>
+                <td><%= row.dimension_value %></td>
+                <td class="has-text-right"><%= number_with_delimiter(row.species_count) %></td>
+                <td class="has-text-right"><%= number_with_delimiter(row.filled_count) %></td>
+                <td class="has-text-right"><%= number_with_delimiter(row.implausible_count) %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      <% else %>
+        <p class="has-text-grey">No provenance facts yet — facts are recorded as crawlers and corrections ingest data.</p>
+      <% end %>
+    </div>
+  </div>
+
+  <% if @history.length > 1 %>
+    <h2 class="subtitle mt-5">Trend</h2>
+    <table class="table is-narrow">
+      <thead><tr><th>Date</th><th class="has-text-right">Species</th><th class="has-text-right">Avg completion</th><th class="has-text-right">Implausible</th><th class="has-text-right">Conflicts</th></tr></thead>
+      <tbody>
+        <% @history.each do |row| %>
+          <tr>
+            <td><%= row.snapshot_on %></td>
+            <td class="has-text-right"><%= number_with_delimiter(row.species_count) %></td>
+            <td class="has-text-right"><%= row.details&.dig('avg_completion_ratio') || '—' %>%</td>
+            <td class="has-text-right"><%= number_with_delimiter(row.implausible_count) %></td>
+            <td class="has-text-right"><%= number_with_delimiter(row.conflict_count) %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
+
+<% end %>
+
+<h2 class="subtitle mt-5">Work queue — most requested, least complete</h2>
+<% if @priorities.any? %>
+  <p class="is-size-7 has-text-grey">Demand signal: <%= @priorities.first.signal %></p>
+  <table class="table is-fullwidth is-striped is-narrow">
+    <thead><tr><th>Species</th><th class="has-text-right">Completion</th><th class="has-text-right">Demand</th><th></th></tr></thead>
+    <tbody>
+      <% @priorities.each do |row| %>
+        <tr>
+          <td><em><%= row.scientific_name %></em></td>
+          <td class="has-text-right"><%= row.completion_ratio || 0 %>%</td>
+          <td class="has-text-right"><%= number_with_delimiter(row.demand) %></td>
+          <td><%= link_to 'Edit', management_species_path(row.id) %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <p class="has-text-grey">No demand data in this environment.</p>
+<% end %>

--- a/app/views/management/layouts/_header.html.erb
+++ b/app/views/management/layouts/_header.html.erb
@@ -21,6 +21,7 @@
         <span class="tag is-info is-small"><%= RecordCorrection.pending_change_status.count %><span>
       <% end %>
       <%= link_to('Chaos', chaos_management_species_images_path, class: 'navbar-item') %>
+      <%= link_to('Data quality', management_data_quality_path, class: 'navbar-item') %>
       <%= link_to('Queries', management_user_queries_path, class: 'navbar-item') %>
       <%= link_to('Stats', stats_management_user_queries_path, class: 'navbar-item') %>
       <%= link_to('Users', management_users_path, class: 'navbar-item') %>

--- a/app/workers/migrators/completion_worker.rb
+++ b/app/workers/migrators/completion_worker.rb
@@ -1,0 +1,25 @@
+# Recomputes completion_ratio / complete_data for every species after a
+# change of the completion definition (config/traits.yml). Replayable.
+class Migrators::CompletionWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: :migrations, retry: false, backtrace: true
+
+  def perform(*_args)
+    done = 0
+    # rubocop:disable Rails/SkipsModelValidations -- deliberate: mass recompute without touching updated_at
+    Species.find_each(batch_size: 1000) do |species|
+      ratio = species.current_completion_percentage
+      species.update_columns(completion_ratio: ratio, complete_data: ratio > 50)
+      done += 1
+    end
+
+    Plant.includes(:main_species).find_each(batch_size: 1000) do |plant|
+      ratio = plant.current_completion_percentage
+      plant.update_columns(completion_ratio: ratio, complete_data: ratio > 25)
+    end
+    # rubocop:enable Rails/SkipsModelValidations
+
+    Rails.logger.info("[Migrators::CompletionWorker] recomputed #{done} species")
+    true
+  end
+end

--- a/app/workers/quality_snapshot_worker.rb
+++ b/app/workers/quality_snapshot_worker.rb
@@ -1,0 +1,12 @@
+# Writes the weekly data-quality snapshot (fill rates, implausible values,
+# source conflicts) — see Quality::Snapshot and DataQualitySnapshot.
+class QualitySnapshotWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :low, retry: false, backtrace: true
+
+  def perform
+    result = Quality::Snapshot.run!
+    Rails.logger.info("[QualitySnapshotWorker] #{result.inspect}")
+  end
+end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,6 +1,16 @@
 {
   "ignored_warnings": [
     {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "1f0d39b87a195d14d008f9db31aada1aeb14dbf6ffa22a138e6fece9bfbd8566",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "lib/quality/snapshot.rb",
+      "line": 60,
+      "note": "Interpolated identifiers are trait field names from config/traits.yml, whitelisted against Species.column_names in run!; never user input."
+    },
+    {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 4,
       "fingerprint": "0bbb94aebd32515b3c63059b19035302492cb3cf424bf062f0e451ea78ba6160",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,7 @@ Rails.application.routes.draw do
       resources :species, only: %i[index show] do
         resources :record_corrections, only: %i[index], path: 'corrections'
         post '/report', action: :report, on: :member
+        get '/facts', action: :facts, on: :member
         get '/search', action: :search, on: :collection
       end
 
@@ -83,6 +84,7 @@ Rails.application.routes.draw do
     end
 
     get '/', to: 'plants#index'
+    get '/data_quality', to: 'data_quality#index'
 
     resources :users
     resources :user_queries do

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -29,3 +29,8 @@ check_species_images:
   cron: "0 0 */7 * *" # At 00:00 on every 7th day-of-month.
   class: "Migrators::ImagesFixerWorker"
   queue: migrations
+
+quality_snapshot:
+  cron: "30 2 * * 1" # Mondays at 02:30 — weekly data quality snapshot
+  class: "QualitySnapshotWorker"
+  queue: low

--- a/config/traits.yml
+++ b/config/traits.yml
@@ -1,0 +1,146 @@
+# Traits contract — single source of truth for species data fields.
+#
+# Used by:
+#   - Species#current_completion_percentage (which fields count, when they apply)
+#   - Ingester source arbitration (which source wins on conflict)
+#   - Checks::PlausibleValues (plausible_range / cross-field rules)
+#   - lib/tasks/quality.rake (data quality snapshots)
+#
+# Field keys:
+#   category:         core | descriptive | media | morphology | phenology |
+#                     ecology | cultivation | usda_legacy | deprecated | derived
+#                     Only categories listed under completion.counted_categories
+#                     are part of the completion ratio.
+#   unit:             informative (cm, mm, deg_c, ph, index_0_10...)
+#   plausible_range:  [min, max] — numeric values outside are rejected by the
+#                     ingester and flagged by Checks::PlausibleValues
+#   applicable_if:    always (default) | edible_or_vegetable — a field only
+#                     counts as "missing" when it is applicable
+#   zero_means_empty: true for bitmask flags / enums where 0 = "not documented"
+
+version: 1
+
+completion:
+  counted_categories: [descriptive, media, morphology, phenology, ecology, cultivation]
+
+sources:
+  # Strongest first. Compared case-insensitively against foreign_sources.slug.
+  # "community" = human-reviewed corrections (RecordCorrection acceptance).
+  # Unknown sources rank after everything listed here.
+  default_priority:
+    - community
+    - iucn
+    - try
+    - powo
+    - wfo
+    - ipni
+    - world_flora_online
+    - gbif
+    - usda
+    - tropicos
+    - tela-botanica
+    - catminat
+    - eol
+    - plantnet
+    - openfarm
+    - wikipedia
+
+cross_field_rules:
+  - { min: ph_minimum, max: ph_maximum }
+  - { min: minimum_temperature_deg_c, max: maximum_temperature_deg_c }
+  - { min: minimum_precipitation_mm, max: maximum_precipitation_mm }
+  - { min: average_height_cm, max: maximum_height_cm }
+
+fields:
+  # --- Core nomenclature (not counted: near-always present, not a trait) ---
+  scientific_name: { category: core }
+  author: { category: core }
+  year: { category: core, plausible_range: [1753, 2100] }
+  bibliography: { category: core }
+  rank: { category: core }
+  status: { category: core }
+
+  # --- Descriptive ---
+  common_name: { category: descriptive }
+  observations: { category: descriptive }
+
+  # --- Media ---
+  main_image_url: { category: media }
+
+  # --- Morphology ---
+  average_height_cm: { category: morphology, unit: cm, plausible_range: [1, 12000] }
+  maximum_height_cm: { category: morphology, unit: cm, plausible_range: [1, 13000] }
+  ligneous_type: { category: morphology }
+  growth_form: { category: morphology }
+  growth_habit: { category: morphology }
+  growth_rate: { category: morphology }
+  shape_and_orientation: { category: morphology }
+  foliage_texture: { category: morphology }
+  foliage_color: { category: morphology, zero_means_empty: true }
+  leaf_retention: { category: morphology }
+  flower_color: { category: morphology, zero_means_empty: true }
+  flower_conspicuous: { category: morphology }
+  fruit_color: { category: morphology, zero_means_empty: true }
+  fruit_conspicuous: { category: morphology }
+  fruit_shape: { category: morphology }
+  fruit_seed_persistence: { category: morphology }
+  inflorescence_form: { category: morphology }
+  inflorescence_type: { category: morphology }
+  sexuality: { category: morphology, zero_means_empty: true }
+  pollinisation: { category: morphology, zero_means_empty: true }
+  dissemination: { category: morphology, zero_means_empty: true }
+  biological_type: { category: morphology }
+  toxicity: { category: morphology }
+  edible_part: { category: morphology, zero_means_empty: true }
+  vegetable: { category: morphology }
+
+  # --- Phenology (bitmask flags: 0 = undocumented) ---
+  duration: { category: phenology, zero_means_empty: true }
+  growth_months: { category: phenology, zero_means_empty: true }
+  bloom_months: { category: phenology, zero_means_empty: true }
+  fruit_months: { category: phenology, zero_means_empty: true }
+
+  # --- Ecology (light/humidity/soil indices are 0-10 Ellenberg-like scales
+  #     from Baseflor/Catminat: 0 is a meaningful value, never "empty") ---
+  light: { category: ecology, unit: index_0_10, plausible_range: [0, 10] }
+  atmospheric_humidity: { category: ecology, unit: index_0_10, plausible_range: [0, 10] }
+  ground_humidity: { category: ecology, unit: index_0_10, plausible_range: [0, 10] }
+  soil_texture: { category: ecology, plausible_range: [1, 9] }
+  soil_salinity: { category: ecology, unit: index_0_10, plausible_range: [0, 10] }
+  soil_nutriments: { category: ecology, unit: index_0_10, plausible_range: [0, 10] }
+  ph_minimum: { category: ecology, unit: ph, plausible_range: [1, 12] }
+  ph_maximum: { category: ecology, unit: ph, plausible_range: [1, 12] }
+  minimum_temperature_deg_c: { category: ecology, unit: deg_c, plausible_range: [-90, 60] }
+  maximum_temperature_deg_c: { category: ecology, unit: deg_c, plausible_range: [-60, 90] }
+  minimum_precipitation_mm: { category: ecology, unit: mm, plausible_range: [0, 15000] }
+  maximum_precipitation_mm: { category: ecology, unit: mm, plausible_range: [0, 15000] }
+  hardiness_zone: { category: ecology, plausible_range: [1, 13] }
+  nitrogen_fixation: { category: ecology }
+
+  # --- Cultivation (only "missing" for edible/vegetable species) ---
+  planting_description: { category: cultivation, applicable_if: edible_or_vegetable }
+  planting_sowing_description: { category: cultivation, applicable_if: edible_or_vegetable }
+  planting_days_to_harvest: { category: cultivation, unit: days, plausible_range: [1, 3650], applicable_if: edible_or_vegetable }
+  planting_row_spacing_cm: { category: cultivation, unit: cm, plausible_range: [1, 10000], applicable_if: edible_or_vegetable }
+  planting_spread_cm: { category: cultivation, unit: cm, plausible_range: [1, 10000], applicable_if: edible_or_vegetable }
+  minimum_root_depth_cm: { category: cultivation, unit: cm, plausible_range: [1, 3000] }
+  edible: { category: derived } # derived from edible_part / vegetable in the serializer
+
+  # --- USDA legacy (US-only agronomic ratings, not exposed by the API,
+  #     kept in DB but excluded from completion) ---
+  frost_free_days_minimum: { category: usda_legacy, plausible_range: [0, 365] }
+  protein_potential: { category: usda_legacy }
+  adapted_to_coarse_textured_soils: { category: usda_legacy }
+  adapted_to_medium_textured_soils: { category: usda_legacy }
+  adapted_to_fine_textured_soils: { category: usda_legacy }
+  anaerobic_tolerance: { category: usda_legacy }
+  c_n_ratio: { category: usda_legacy }
+  known_allelopath: { category: usda_legacy }
+  caco_3_tolerance: { category: usda_legacy }
+  lifespan: { category: usda_legacy }
+  maturation_order: { category: usda_legacy }
+
+  # --- Deprecated / derived duplicates ---
+  propagated_by: { category: deprecated } # marked @TODO DEPRECATED in the model
+  minimum_temperature_deg_f: { category: derived } # dup of deg_c
+  maximum_temperature_deg_f: { category: derived } # dup of deg_c

--- a/db/migrate/20260904100000_create_species_facts.rb
+++ b/db/migrate/20260904100000_create_species_facts.rb
@@ -1,0 +1,28 @@
+class CreateSpeciesFacts < ActiveRecord::Migration[8.0]
+  def change
+    create_table :species_facts do |t|
+      t.bigint :species_id, null: false
+      t.string :attribute_name, null: false
+      t.string :source, null: false # foreign_sources slug, or "community"/"unknown"
+      t.string :value # normalized string form of the value
+      t.decimal :value_numeric # populated when the value is numeric
+      t.string :unit
+      t.integer :evidence_type, default: 0, null: false # reported/measured/derived/inferred
+      t.integer :status, default: 0, null: false # active/superseded/rejected/outranked
+      t.string :source_record_id # id of the record at the source (fid)
+      t.string :source_url
+      t.text :notes # e.g. rejection reason
+      t.integer :n_observations
+      t.datetime :observed_at
+
+      t.timestamps
+    end
+
+    add_index :species_facts, %i[species_id attribute_name]
+    add_index :species_facts, %i[attribute_name status]
+    # One active fact per (species, attribute, source)
+    add_index :species_facts, %i[species_id attribute_name source],
+              unique: true, where: 'status = 0', name: 'idx_species_facts_one_active_per_source'
+    add_foreign_key :species_facts, :species
+  end
+end

--- a/db/migrate/20260904100001_create_data_quality_snapshots.rb
+++ b/db/migrate/20260904100001_create_data_quality_snapshots.rb
@@ -1,0 +1,21 @@
+class CreateDataQualitySnapshots < ActiveRecord::Migration[8.0]
+  def change
+    create_table :data_quality_snapshots do |t|
+      t.date :snapshot_on, null: false
+      t.string :dimension, null: false # global / rank / family / source
+      t.string :dimension_value # e.g. "species", "Rosaceae", "gbif"
+      t.string :attribute_name # a species column, or null for the aggregate row
+      t.integer :species_count, default: 0, null: false
+      t.integer :filled_count, default: 0, null: false
+      t.integer :implausible_count, default: 0, null: false
+      t.integer :conflict_count, default: 0, null: false
+      t.jsonb :details, default: {}
+
+      t.timestamps
+    end
+
+    add_index :data_quality_snapshots,
+              %i[snapshot_on dimension dimension_value attribute_name],
+              unique: true, name: 'idx_quality_snapshots_unique'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_09_30_132420) do
+ActiveRecord::Schema[8.0].define(version: 2026_09_04_100001) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
-  enable_extension "plpgsql"
 
   create_table "common_names", force: :cascade do |t|
     t.string "record_type", null: false
@@ -23,6 +23,21 @@ ActiveRecord::Schema[7.0].define(version: 2025_09_30_132420) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["record_type", "record_id"], name: "index_common_names_on_record_type_and_record_id"
+  end
+
+  create_table "data_quality_snapshots", force: :cascade do |t|
+    t.date "snapshot_on", null: false
+    t.string "dimension", null: false
+    t.string "dimension_value"
+    t.string "attribute_name"
+    t.integer "species_count", default: 0, null: false
+    t.integer "filled_count", default: 0, null: false
+    t.integer "implausible_count", default: 0, null: false
+    t.integer "conflict_count", default: 0, null: false
+    t.jsonb "details", default: {}
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["snapshot_on", "dimension", "dimension_value", "attribute_name"], name: "idx_quality_snapshots_unique", unique: true
   end
 
   create_table "division_classes", force: :cascade do |t|
@@ -472,6 +487,27 @@ ActiveRecord::Schema[7.0].define(version: 2025_09_30_132420) do
     t.index ["zone_id"], name: "index_species_distributions_on_zone_id"
   end
 
+  create_table "species_facts", force: :cascade do |t|
+    t.bigint "species_id", null: false
+    t.string "attribute_name", null: false
+    t.string "source", null: false
+    t.string "value"
+    t.decimal "value_numeric"
+    t.string "unit"
+    t.integer "evidence_type", default: 0, null: false
+    t.integer "status", default: 0, null: false
+    t.string "source_record_id"
+    t.string "source_url"
+    t.text "notes"
+    t.integer "n_observations"
+    t.datetime "observed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["attribute_name", "status"], name: "index_species_facts_on_attribute_name_and_status"
+    t.index ["species_id", "attribute_name", "source"], name: "idx_species_facts_one_active_per_source", unique: true, where: "(status = 0)"
+    t.index ["species_id", "attribute_name"], name: "index_species_facts_on_species_id_and_attribute_name"
+  end
+
   create_table "species_images", force: :cascade do |t|
     t.string "image_url", limit: 255, null: false
     t.integer "species_id"
@@ -704,6 +740,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_09_30_132420) do
   add_foreign_key "species", "plants", name: "species_plant_id_fkey"
   add_foreign_key "species_distributions", "species"
   add_foreign_key "species_distributions", "zones"
+  add_foreign_key "species_facts", "species"
   add_foreign_key "species_proposals", "genuses", column: "genus_id", name: "species_proposals_genus_id_fkey"
   add_foreign_key "species_proposals", "users", name: "species_proposals_user_id_fkey"
   add_foreign_key "species_trends", "foreign_sources"

--- a/lib/checks.rb
+++ b/lib/checks.rb
@@ -3,7 +3,7 @@ module Checks
   # Checks::NameAcceptance (external APIs) and Checks::SpeciesDuplicates
   # (whole-table scan) are heavier and must be scheduled on their own.
   def self.run_all(species_id)
-    [Checks::GenusName, Checks::GenusSpecies, Checks::ScientificNameFormat].map do |check|
+    [Checks::GenusName, Checks::GenusSpecies, Checks::ScientificNameFormat, Checks::PlausibleValues].map do |check|
       check.run(species_id)
     end
   end

--- a/lib/checks/check.rb
+++ b/lib/checks/check.rb
@@ -27,7 +27,7 @@ module Checks
         )
       else
         correction = JSON.parse(@existing_check.correction_json)
-        i = ::Ingester::Species.new(correction, species_id: @existing_check.record_id)
+        i = ::Ingester::Species.new(correction, species_id: @existing_check.record_id, source: 'community')
         res = i.ingest!
         if res[:valid]
           @existing_check.update(
@@ -69,7 +69,7 @@ module Checks
       return if @existing_check&.reload&.pending_change_status?
 
       if correction
-        result = Ingester::Species.new(correction, dry_run: true, species_id: @species.id).ingest!
+        result = Ingester::Species.new(correction, dry_run: true, species_id: @species.id, source: 'community').ingest!
 
         pp result
         params[:change_notes] = result[:changes].to_json

--- a/lib/checks/plausible_values.rb
+++ b/lib/checks/plausible_values.rb
@@ -1,0 +1,59 @@
+module Checks
+  # Flags numeric trait values outside their plausible_range (config/traits.yml)
+  # and inconsistent min/max pairs. Accepting the warning drops the implausible
+  # values (sets them to nil) and rejects the matching provenance facts.
+  class PlausibleValues < Check
+
+    def run
+      implausible = implausible_fields
+      cross = inconsistent_bounds
+
+      return if implausible.empty? && cross.empty?
+
+      notes = implausible.map {|n, v| "#{n}=#{v} outside plausible range #{Traits.field(n)['plausible_range']}" }
+      notes += cross.map {|c| "inconsistent bounds: #{c}" }
+
+      get_or_create_warning_for_record(
+        notes: notes.join("\n"),
+        correction_json: implausible.to_h {|n, _v| [n, nil] }.to_json
+      )
+    end
+
+    # Accepting means: these values are wrong, drop them.
+    def accept!(user_id = nil)
+      return unless @existing_check&.pending_change_status?
+
+      fields = JSON.parse(@existing_check.correction_json || '{}').keys & Species.column_names
+      @species.update!(fields.index_with { nil }) if fields.any?
+
+      @species.species_facts.active_status.where(attribute_name: fields).find_each do |f|
+        f.update!(status: :rejected, notes: [f.notes, 'rejected via Checks::PlausibleValues'].compact.join("\n"))
+      end
+
+      @existing_check.update(accepted_by: user_id, change_status: :accepted)
+    end
+
+    private
+
+    def implausible_fields
+      Traits.fields.keys.filter_map do |name|
+        value = @species.attributes[name]
+        next unless value.is_a?(Numeric)
+        next if Traits.plausible?(name, value)
+
+        [name, value]
+      end
+    end
+
+    def inconsistent_bounds
+      Traits.cross_field_rules.filter_map do |rule|
+        min = @species.attributes[rule['min']]
+        max = @species.attributes[rule['max']]
+        next unless min.is_a?(Numeric) && max.is_a?(Numeric) && min > max
+
+        "#{rule['min']}=#{min} > #{rule['max']}=#{max}"
+      end
+    end
+
+  end
+end

--- a/lib/ingester/species.rb
+++ b/lib/ingester/species.rb
@@ -21,6 +21,9 @@ module Ingester
       @data = data&.deep_symbolize_keys&.compact
       # @data[:scientific_name] = "Mama mia"
       @dry_run = options[:dry_run] || false
+      # Explicit source of this ingestion (e.g. 'community' for accepted
+      # corrections). Otherwise inferred from the source_* keys of the data.
+      @source = options[:source]&.to_s
       @species = ::Species.friendly.find(options[:species_id]) if options[:species_id]
 
       return unless @data
@@ -51,6 +54,10 @@ module Ingester
 
       # We apply all the data we have on it
       assign_attributes!
+
+      # Source arbitration on trait fields: reject implausible values, keep the
+      # column value of a stronger source, and collect provenance facts
+      @pending_facts = arbitrate_traits!
 
       # We update it (or juste return the changes if dry run)
       save_or_return!
@@ -112,6 +119,7 @@ module Ingester
         puts "  saved_changes: #{@species.saved_changes}"
 
         if a
+          persist_facts!
           puts '[Ingester] Ingested !'
         else
           puts "[Ingester] Errors while saving: #{@species.errors.full_messages}"
@@ -222,6 +230,73 @@ module Ingester
         valid: @species&.valid?,
         errors: @species&.errors&.full_messages
       }
+    end
+
+    # --- Source arbitration & provenance -----------------------------------
+
+    RESERVED_SOURCE_KEYS = %w[id name type reference url].freeze
+
+    # The source of this ingestion: explicit option, else inferred from the
+    # source_* keys of the data (strongest one if several), else 'unknown'.
+    def detected_source
+      return @source if @source.present?
+
+      slugs = @data.keys.map(&:to_s)
+        .filter {|k| k.start_with?('source_') }
+        .map {|k| k.sub(/\Asource_/, '') }
+        .reject {|s| RESERVED_SOURCE_KEYS.include?(s) }
+        .map {|s| s.sub(/_[a-z]{2}\z/, '') } # source_wikipedia_en -> wikipedia
+
+      slugs.min_by {|s| Traits.priority_index(s) } || 'unknown'
+    end
+
+    # For each changed trait field:
+    # - implausible value  -> revert the assignment, fact recorded as :rejected
+    # - stronger source already claims this attribute and the column is filled
+    #   -> revert the assignment (the claim is still recorded as :active)
+    # Returns the facts to persist after a successful save.
+    def arbitrate_traits!
+      source = detected_source
+      facts = []
+
+      @species.changes.slice(*Traits.completion_fields).each do |attr, (old_value, new_value)|
+        next if new_value.nil?
+
+        unless Traits.plausible?(attr, new_value)
+          @species.send("#{attr}=", old_value)
+          facts << { attribute_name: attr, source: source, value: new_value,
+                     status: :rejected,
+                     notes: "implausible: outside #{Traits.field(attr)['plausible_range']}" }
+          next
+        end
+
+        if Traits.filled?(attr, old_value) && outranked_by_stronger_fact?(attr, source)
+          puts "[Ingester][Arbitration] keeping #{attr} (a stronger source claims it, '#{source}' recorded as fact only)"
+          @species.send("#{attr}=", old_value)
+        end
+
+        facts << { attribute_name: attr, source: source, value: new_value, status: :active }
+      end
+
+      facts
+    end
+
+    def outranked_by_stronger_fact?(attr, source)
+      return false unless @species.persisted?
+
+      strongest_other = @species.species_facts.active_status.for_attribute(attr)
+        .where.not(source: source)
+        .min_by {|f| Traits.priority_index(f.source) }
+
+      strongest_other && Traits.priority_index(strongest_other.source) < Traits.priority_index(source)
+    end
+
+    def persist_facts!
+      (@pending_facts || []).each do |fact|
+        ::SpeciesFact.record!(species: @species, **fact)
+      end
+    rescue StandardError => e
+      Rails.logger.warn("[Ingester] Unable to record facts for #{@species&.scientific_name}: #{e.message}")
     end
 
   end

--- a/lib/quality.rb
+++ b/lib/quality.rb
@@ -1,0 +1,2 @@
+module Quality
+end

--- a/lib/quality/priorities.rb
+++ b/lib/quality/priorities.rb
@@ -1,0 +1,49 @@
+module Quality
+  # The work queue: most requested species with the poorest data.
+  # Demand signal: species_trends, falling back to wiki_score, then gbif_score.
+  class Priorities
+
+    Row = Struct.new(:id, :slug, :scientific_name, :completion_ratio, :demand, :signal, keyword_init: true)
+
+    def self.fetch(limit: 100, max_completion: 50)
+      queries(limit, max_completion).each do |signal, sql|
+        rows = ActiveRecord::Base.connection.select_all(sql).to_a
+        next if rows.empty?
+
+        return rows.map {|r| Row.new(signal: signal, **r.symbolize_keys) }
+      end
+
+      []
+    end
+
+    def self.queries(limit, max_completion)
+      [
+        [:species_trends, <<~SQL],
+          SELECT s.id, s.slug, s.scientific_name, s.completion_ratio, t.demand
+          FROM species s
+          INNER JOIN (
+            SELECT species_id, SUM(score) AS demand
+            FROM species_trends
+            GROUP BY species_id
+          ) t ON t.species_id = s.id
+          WHERE COALESCE(s.completion_ratio, 0) < #{max_completion.to_i}
+          ORDER BY t.demand DESC, COALESCE(s.completion_ratio, 0) ASC
+          LIMIT #{limit.to_i}
+        SQL
+        [:wiki_score, <<~SQL],
+          SELECT id, slug, scientific_name, completion_ratio, wiki_score AS demand
+          FROM species WHERE wiki_score > 0 AND COALESCE(completion_ratio, 0) < #{max_completion.to_i}
+          ORDER BY wiki_score DESC, COALESCE(completion_ratio, 0) ASC LIMIT #{limit.to_i}
+        SQL
+        [:gbif_score, <<~SQL]
+          SELECT id, slug, scientific_name, completion_ratio, gbif_score AS demand
+          FROM species WHERE gbif_score > 0 AND COALESCE(completion_ratio, 0) < #{max_completion.to_i}
+          ORDER BY gbif_score DESC, COALESCE(completion_ratio, 0) ASC LIMIT #{limit.to_i}
+        SQL
+      ]
+    end
+
+    private_class_method :queries
+
+  end
+end

--- a/lib/quality/snapshot.rb
+++ b/lib/quality/snapshot.rb
@@ -1,0 +1,130 @@
+module Quality
+  # Writes the dated data-quality rows (see DataQualitySnapshot):
+  # fill rate / implausible count / conflict count per trait field, plus
+  # aggregates per rank and per source. One species-table scan.
+  class Snapshot
+
+    def self.run!(date: Time.zone.today)
+      new(date).run!
+    end
+
+    def initialize(date = Time.zone.today)
+      @date = date
+    end
+
+    def run!
+      # Hard whitelist: field names get interpolated in SQL, only actual
+      # species columns (as declared in config/traits.yml) may pass.
+      fields = Traits.completion_fields & Species.column_names
+      total = Species.count
+      row = fill_rates_row(fields)
+      conflicts_by_attr = conflict_counts
+
+      DataQualitySnapshot.transaction do
+        write_field_rows!(fields, total, row, conflicts_by_attr)
+        write_global_aggregate!(fields, total, row, conflicts_by_attr)
+        write_rank_rows!
+        write_source_rows!
+      end
+
+      { date: @date, species_count: total, fields_count: fields.length }
+    end
+
+    private
+
+    # SQL expression counting a field as "filled", honouring zero_means_empty
+    # and blank strings (mirrors Traits.filled?)
+    def filled_expression(name)
+      column = Species.columns_hash[name]
+
+      if Traits.field(name)['zero_means_empty']
+        "COUNT(NULLIF(#{name}, 0))"
+      elsif %i[string text].include?(column.type)
+        "COUNT(NULLIF(BTRIM(#{name}), ''))"
+      else
+        "COUNT(#{name})"
+      end
+    end
+
+    def implausible_expression(name)
+      range = Traits.field(name)['plausible_range']
+      return '0' unless range
+
+      "SUM(CASE WHEN #{name} IS NOT NULL AND (#{name} < #{range[0]} OR #{name} > #{range[1]}) THEN 1 ELSE 0 END)"
+    end
+
+    def fill_rates_row(fields)
+      selects = fields.flat_map do |f|
+        ["#{filled_expression(f)} AS filled_#{f}", "#{implausible_expression(f)} AS implausible_#{f}"]
+      end
+      ActiveRecord::Base.connection.select_one("SELECT #{selects.join(', ')} FROM species")
+    end
+
+    # (species, attribute) pairs where active facts disagree, per attribute
+    def conflict_counts
+      ActiveRecord::Base.connection.select_all(<<~SQL).to_a.to_h {|c| [c['attribute_name'], c['conflict_count'].to_i] }
+        SELECT attribute_name, COUNT(*) AS conflict_count FROM (
+          SELECT species_id, attribute_name
+          FROM species_facts
+          WHERE status = 0
+          GROUP BY species_id, attribute_name
+          HAVING COUNT(DISTINCT value) > 1
+        ) c GROUP BY attribute_name
+      SQL
+    end
+
+    def write_field_rows!(fields, total, row, conflicts_by_attr)
+      fields.each do |f|
+        DataQualitySnapshot.find_or_initialize_by(
+          snapshot_on: @date, dimension: 'global', dimension_value: nil, attribute_name: f
+        ).update!(
+          species_count: total,
+          filled_count: row["filled_#{f}"].to_i,
+          implausible_count: row["implausible_#{f}"].to_i,
+          conflict_count: conflicts_by_attr.fetch(f, 0)
+        )
+      end
+    end
+
+    def write_global_aggregate!(fields, total, row, conflicts_by_attr)
+      DataQualitySnapshot.find_or_initialize_by(
+        snapshot_on: @date, dimension: 'global', dimension_value: nil, attribute_name: nil
+      ).update!(
+        species_count: total,
+        filled_count: fields.sum {|f| row["filled_#{f}"].to_i },
+        implausible_count: fields.sum {|f| row["implausible_#{f}"].to_i },
+        conflict_count: conflicts_by_attr.values.sum,
+        details: {
+          fields_count: fields.length,
+          avg_completion_ratio: Species.average(:completion_ratio)&.round(1)&.to_f
+        }
+      )
+    end
+
+    def write_rank_rows!
+      Species.group(:rank).count.each do |rank, count|
+        DataQualitySnapshot.find_or_initialize_by(
+          snapshot_on: @date, dimension: 'rank', dimension_value: rank || 'unknown', attribute_name: nil
+        ).update!(
+          species_count: count,
+          details: { avg_completion_ratio: Species.where(rank: rank).average(:completion_ratio)&.round(1)&.to_f }
+        )
+      end
+    end
+
+    def write_source_rows!
+      SpeciesFact.group(:source, :status).count.group_by {|(source, _), _| source }.each do |source, rows|
+        by_status = rows.to_h {|(_, status), count| [status, count] }
+        DataQualitySnapshot.find_or_initialize_by(
+          snapshot_on: @date, dimension: 'source', dimension_value: source, attribute_name: nil
+        ).update!(
+          species_count: by_status.values.sum,
+          filled_count: by_status.fetch('active', 0),
+          implausible_count: by_status.fetch('rejected', 0),
+          details: by_status
+        )
+      end
+    end
+
+  end
+end

--- a/lib/tasks/quality.rake
+++ b/lib/tasks/quality.rake
@@ -1,0 +1,42 @@
+# Data quality measurement (see config/traits.yml).
+#
+#   rake quality:snapshot             # write dated quality rows (trend tracking)
+#   rake quality:priorities           # most requested species with poor data
+#   rake quality:recompute_completion # refresh completion_ratio on all species
+namespace :quality do
+
+  desc 'Write data quality snapshot rows for today (global, per field, per rank, per source)'
+  task snapshot: :environment do
+    result = Quality::Snapshot.run!
+
+    puts "Snapshot #{result[:date]}: #{result[:species_count]} species, #{result[:fields_count]} fields"
+    DataQualitySnapshot.on(result[:date]).global.where.not(attribute_name: nil)
+      .sort_by {|s| s.fill_rate || 0 }.each do |s|
+      puts format('  %-32<name>s %6.1<fill>f%% filled  %6<implausible>d implausible  %6<conflicts>d conflicts',
+                  name: s.attribute_name, fill: s.fill_rate || 0,
+                  implausible: s.implausible_count, conflicts: s.conflict_count)
+    end
+  end
+
+  desc 'Most requested species with the poorest data — the work queue'
+  task priorities: :environment do
+    rows = Quality::Priorities.fetch(limit: (ENV['LIMIT'] || 100).to_i)
+
+    next puts('No demand data (species_trends, wiki_score and gbif_score are all empty).') if rows.empty?
+
+    line = '%-8<id>s %-40<name>s %-12<completion>s %<demand>s'
+    puts "(demand signal: #{rows.first.signal})"
+    puts format(line, id: 'id', name: 'scientific_name', completion: 'completion', demand: 'demand')
+    rows.each do |r|
+      puts format(line, id: r.id, name: r.scientific_name,
+                        completion: "#{r.completion_ratio || 0}%", demand: r.demand)
+    end
+  end
+
+  desc 'Recompute completion_ratio/complete_data for every species and plant (no callbacks)'
+  task recompute_completion: :environment do
+    Migrators::CompletionWorker.new.perform
+    puts 'Done (details in the Rails log)'
+  end
+
+end

--- a/lib/traits.rb
+++ b/lib/traits.rb
@@ -1,0 +1,88 @@
+# Reads config/traits.yml — the per-field data contract used for the
+# completion ratio, ingester source arbitration and data quality checks.
+module Traits
+  class << self
+
+    def config
+      @config ||= YAML.load_file(Rails.root.join('config/traits.yml'))
+    end
+
+    # Used by tests to force a reload
+    def reset!
+      @config = nil
+      @completion_fields = nil
+      @source_priority = nil
+    end
+
+    def fields
+      config['fields']
+    end
+
+    def field(name)
+      fields[name.to_s]
+    end
+
+    def counted_categories
+      config.dig('completion', 'counted_categories')
+    end
+
+    # Field names participating in the completion ratio
+    def completion_fields
+      @completion_fields ||= fields.select {|_, spec| counted_categories.include?(spec['category']) }.keys
+    end
+
+    # A field only counts as "missing" when it makes sense for this species
+    # (e.g. planting_* fields for edible/vegetable species only)
+    def applicable?(name, species)
+      case field(name)&.fetch('applicable_if', 'always')
+      when 'edible_or_vegetable'
+        species.vegetable || species.edible || species.edible_part&.any? ? true : false
+      else
+        true
+      end
+    end
+
+    # Is this raw attribute value considered filled?
+    # - false is information (e.g. leaf_retention: false)
+    # - 0 is information, except for bitmask/enum fields where 0 = undocumented
+    def filled?(name, value)
+      return true if value == false
+      return false if value.nil?
+      return false if value.is_a?(String) && value.strip.empty?
+      return false if field(name)&.dig('zero_means_empty') && value.respond_to?(:zero?) && value.zero?
+
+      true
+    end
+
+    # Numeric plausibility according to plausible_range. Non-numeric values and
+    # fields without a range are always considered plausible here.
+    def plausible?(name, value)
+      range = field(name)&.dig('plausible_range')
+      return true unless range && value.is_a?(Numeric)
+
+      value >= range[0] && value <= range[1]
+    end
+
+    def cross_field_rules
+      config['cross_field_rules'] || []
+    end
+
+    # --- Source arbitration -------------------------------------------------
+
+    def source_priority
+      @source_priority ||= config.dig('sources', 'default_priority').map(&:downcase)
+    end
+
+    # Lower index = stronger source. Unknown sources rank last.
+    def priority_index(source)
+      return source_priority.length if source.nil?
+
+      source_priority.index(source.to_s.downcase) || source_priority.length
+    end
+
+    def stronger_or_equal?(source, other)
+      priority_index(source) <= priority_index(other)
+    end
+
+  end
+end

--- a/spec/lib/checks_plausible_values_spec.rb
+++ b/spec/lib/checks_plausible_values_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe Checks::PlausibleValues do
+  let(:species) { Species.friendly.find('abies-alba') }
+
+  it 'does nothing when values are plausible' do
+    species.update_columns(average_height_cm: 150, ph_minimum: 5.0, ph_maximum: 7.0)
+
+    expect { described_class.run(species.id) }.not_to change(RecordCorrection, :count)
+  end
+
+  it 'flags a value outside its plausible range' do
+    species.update_columns(average_height_cm: 999_999)
+
+    expect { described_class.run(species.id) }.to change(RecordCorrection, :count).by(1)
+
+    warning = RecordCorrection.find_by(warning_type: 'Checks::PlausibleValues')
+    expect(warning).to be_pending_change_status
+    expect(warning.notes).to include('average_height_cm=999999')
+  end
+
+  it 'flags inconsistent min/max bounds' do
+    species.update_columns(ph_minimum: 8.0, ph_maximum: 5.0)
+
+    expect { described_class.run(species.id) }.to change(RecordCorrection, :count).by(1)
+
+    warning = RecordCorrection.find_by(warning_type: 'Checks::PlausibleValues')
+    expect(warning.notes).to include('inconsistent bounds')
+  end
+
+  it 'accepting the warning drops the implausible values' do
+    species.update_columns(average_height_cm: 999_999)
+    described_class.run(species.id)
+    warning = RecordCorrection.find_by(warning_type: 'Checks::PlausibleValues')
+
+    described_class.new(species.id).accept!(nil)
+
+    expect(species.reload.average_height_cm).to be_nil
+    expect(warning.reload).to be_accepted_change_status
+  end
+
+  it 'resolves the warning once the data is fixed' do
+    species.update_columns(average_height_cm: 999_999)
+    described_class.run(species.id)
+    warning = RecordCorrection.find_by(warning_type: 'Checks::PlausibleValues')
+
+    species.update_columns(average_height_cm: 250)
+    described_class.run(species.id)
+
+    expect(warning.reload).not_to be_pending_change_status
+  end
+end

--- a/spec/lib/ingester_arbitration_spec.rb
+++ b/spec/lib/ingester_arbitration_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+RSpec.describe 'Ingester source arbitration' do
+
+  let(:species) { create(:species) }
+
+  def ingest(data, **options)
+    Ingester::Species.new(data, species_id: species.id, **options).ingest!
+  end
+
+  it 'records an active fact with the detected source' do
+    ingest({ source_gbif: '123', average_height_value: 250, average_height_unit: 'cm' })
+
+    fact = species.species_facts.find_by(attribute_name: 'average_height_cm')
+    expect(fact).not_to be_nil
+    expect(fact.source).to eq('gbif')
+    expect(fact.status).to eq('active')
+    expect(fact.value_numeric).to eq(250)
+    expect(species.reload.average_height_cm).to eq(250)
+  end
+
+  it 'supersedes the previous fact of the same source' do
+    ingest({ source_gbif: '123', average_height_value: 250, average_height_unit: 'cm' })
+    ingest({ source_gbif: '123', average_height_value: 300, average_height_unit: 'cm' })
+
+    facts = species.species_facts.for_attribute('average_height_cm').order(:id)
+    expect(facts.map(&:status)).to eq(%w[superseded active])
+    expect(species.reload.average_height_cm).to eq(300)
+  end
+
+  it 'does not let a weaker source overwrite a stronger one, but keeps its claim' do
+    ingest({ source_powo: 'p1', average_height_value: 250, average_height_unit: 'cm' })
+    ingest({ source_wikipedia: 'Okra', average_height_value: 999, average_height_unit: 'cm' })
+
+    expect(species.reload.average_height_cm).to eq(250)
+
+    wiki_fact = species.species_facts.active_status.find_by(source: 'wikipedia', attribute_name: 'average_height_cm')
+    expect(wiki_fact).not_to be_nil
+    expect(wiki_fact.value_numeric).to eq(999)
+    # The disagreement is visible as a conflict
+    expect(wiki_fact.conflicting_facts.count).to eq(1)
+  end
+
+  it 'lets a stronger source overwrite a weaker one' do
+    ingest({ source_wikipedia: 'Okra', average_height_value: 999, average_height_unit: 'cm' })
+    ingest({ source_powo: 'p1', average_height_value: 250, average_height_unit: 'cm' })
+
+    expect(species.reload.average_height_cm).to eq(250)
+  end
+
+  it 'lets a weak source fill an empty column' do
+    ingest({ source_wikipedia: 'Okra', average_height_value: 180, average_height_unit: 'cm' })
+
+    expect(species.reload.average_height_cm).to eq(180)
+  end
+
+  it 'community corrections always win' do
+    ingest({ source_powo: 'p1', average_height_value: 250, average_height_unit: 'cm' })
+    ingest({ average_height_value: 260, average_height_unit: 'cm' }, source: 'community')
+
+    expect(species.reload.average_height_cm).to eq(260)
+  end
+
+  it 'rejects implausible values without assigning them' do
+    ingest({ source_gbif: '123', average_height_value: 999_999, average_height_unit: 'cm' })
+
+    expect(species.reload.average_height_cm).to be_nil
+    fact = species.species_facts.find_by(attribute_name: 'average_height_cm')
+    expect(fact.status).to eq('rejected')
+    expect(fact.notes).to include('implausible')
+  end
+
+  it 'does not persist facts on dry run' do
+    result = ingest({ source_gbif: '123', average_height_value: 250, average_height_unit: 'cm' }, dry_run: true)
+
+    expect(result[:changes]).to include('average_height_cm' => [nil, 250])
+    expect(species.species_facts.count).to eq(0)
+    expect(species.reload.average_height_cm).to be_nil
+  end
+
+end

--- a/spec/requests/api/v1/4_species_facts_spec.rb
+++ b/spec/requests/api/v1/4_species_facts_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe 'Species facts API', type: :request do
+
+  let(:user) { create(:user) }
+  let(:species) { Species.friendly.find('abies-alba') }
+
+  before do
+    SpeciesFact.record!(species: species, attribute_name: 'average_height_cm', source: 'powo', value: 250)
+    SpeciesFact.record!(species: species, attribute_name: 'average_height_cm', source: 'wikipedia', value: 300)
+  end
+
+  it 'requires authentication' do
+    get "/api/v1/species/#{species.slug}/facts"
+
+    expect(response).to have_http_status(:unauthorized)
+  end
+
+  it 'lists the provenance facts of a species' do
+    get "/api/v1/species/#{species.slug}/facts", params: { token: user.token }
+
+    expect(response).to have_http_status(:ok)
+    body = JSON.parse(response.body)
+    expect(body['meta']['total']).to eq(2)
+
+    fact = body['data'].first
+    expect(fact['attribute_name']).to eq('average_height_cm')
+    expect(fact['source']).to eq('powo')
+    expect(fact['value']).to eq('250')
+    expect(fact['unit']).to eq('cm')
+    expect(fact['status']).to eq('active')
+    expect(fact['evidence_type']).to eq('reported')
+  end
+
+end

--- a/spec/requests/web/management_spec.rb
+++ b/spec/requests/web/management_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Management backoffice', type: :request do
     end
 
     %w[species plants users kingdoms subkingdoms divisions division_classes division_orders
-       families genuses record_corrections user_queries species_images foreign_sources].each do |section|
+       families genuses record_corrections user_queries species_images foreign_sources data_quality].each do |section|
       it "refuses non-admin users on /management/#{section}" do
         login_as create(:user), scope: :user
         get "/management/#{section}"
@@ -28,7 +28,7 @@ RSpec.describe 'Management backoffice', type: :request do
     before { login_as create(:admin), scope: :user }
 
     %w[species plants users kingdoms subkingdoms divisions division_classes division_orders
-       families genuses record_corrections user_queries species_images foreign_sources].each do |section|
+       families genuses record_corrections user_queries species_images foreign_sources data_quality].each do |section|
       it "renders /management/#{section}" do
         get "/management/#{section}"
         expect(response).to have_http_status(:ok)
@@ -38,6 +38,15 @@ RSpec.describe 'Management backoffice', type: :request do
     it 'renders the dashboard' do
       get management_path
       expect(response).to have_http_status(:ok)
+    end
+
+    it 'renders the data quality dashboard with snapshot data' do
+      Quality::Snapshot.run!
+
+      get '/management/data_quality'
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('Fill rate per field')
+      expect(response.body).to include('average_height_cm')
     end
 
     it 'renders a species page and updates it' do


### PR DESCRIPTION
Foundations for filling the database with sourced, verifiable data instead of last-crawler-wins overwrites. Everything is internal or additive: **no existing v1 payload changes** (one bugfix aside, see below).

## What's in here

**Per-field data contract** — `config/traits.yml` + `Traits` module: category, unit, plausible range, applicability and source priority for every species column. Single source of truth for the completion ratio, ingestion arbitration and quality checks.

**Honest completion ratio** — only the 52 actual trait fields count (no cache/identity/USDA-legacy columns), a field is only "missing" when applicable (`planting_*` only for edibles), `false` is a value, and `0` only means empty for bitmask flags. Plants delegate to their main species. `Migrators::CompletionWorker` (replayable) recomputes the stored ratios.

**Provenance facts** — new `species_facts` table: one row per (species, attribute, source) claim, with `evidence_type` (reported/measured/derived/inferred) and `status` (active/superseded/rejected). Recorded automatically by the ingester, so facts accumulate as crawlers and corrections run — no changes needed in the pipeline.

**Source arbitration in the ingester** — the source is detected from the `source_*` keys (accepted corrections ingest as `community`, which always wins). A weaker source no longer overwrites a stronger one: its claim is kept and surfaces as a conflict. Implausible values are rejected before assignment.

**`Checks::PlausibleValues`** — flags out-of-range values and inconsistent min/max pairs (e.g. `ph_minimum > ph_maximum`), wired into the hourly `Checks.run_all` sweep. Accepting the warning drops the values and rejects the matching facts. This gives issues like #90 (implausible soil salinity) a systematic answer.

**Measurement & work queue** — `Quality::Snapshot` writes dated fill-rate/implausible/conflict rows (weekly cron, Monday 02:30); `Quality::Priorities` ranks the most requested species with the poorest data (`species_trends` → `wiki_score` → `gbif_score` fallback). `rake quality:snapshot` / `quality:priorities`. New `/management/data_quality` dashboard (fill rate per field, conflicts, trend, work queue).

**Public API (additive)** — `GET /api/v1/species/:id/facts` exposes the provenance trail.

**Bugfix (separate commit)** — `Plant#hybrids` and `#subvarieties` were swapped, so the public plant payload served each list under the other's key.

## Verification

- 755 examples, 0 failures (baseline before this branch: 737/0), 10 pre-existing pending
- RuboCop: 0 offenses; Brakeman: 0 warnings (one annotated ignore added: the snapshot SQL interpolates field names whitelisted against `Species.column_names`)
- Coverage 67.6% (was 66.3%)
- Snapshot + priorities tasks exercised against a full production dump (489k species) locally

## After deploy

1. Run `Migrators::CompletionWorker` once (or `rake quality:recompute_completion`) — stored ratios date from the old formula.
2. Run `rake quality:snapshot` once to seed the dashboard; the weekly cron takes over from there.

## Conflict check

- Open PR #246 (CORS) touches `Gemfile`/`config/initializers/cors.rb` only — no overlap.
- Migrations use the `[8.0]` API and the worker sticks to the plain Sidekiq API, so #215 (Rails 8.1) and #213 (Sidekiq 8) are unaffected.
- The arbitration lives in the public `lib/ingester`, not in the private crawlers, so it stays compatible with #223 (pipeline extraction).
- Groundwork for #238 (the honest completion ratio is what that page should surface) and #218 (`hardiness_zone` is now in the traits contract with a plausible range).
