### PR TITLE
Typography: self-hosted sans for body copy, mono reserved for data

### DIFF
--- a/app/assets/javascripts/application.scss
+++ b/app/assets/javascripts/application.scss
@@ -19,11 +19,8 @@
 
 // 4. Import the rest of Bulma
 
+@import 'sections/fonts';
 
-@import url('https://fonts.googleapis.com/css?family=Roboto+Mono:300,400,500,700');
-
-
-$family-monospace: 'Roboto Mono', monospace;
 $green: #41b913;
 $blue: #3273dc;
 $primary: $green;

--- a/app/assets/javascripts/sections/_explore.scss
+++ b/app/assets/javascripts/sections/_explore.scss
@@ -121,7 +121,7 @@
     align-items: flex-start;
     
     h2.title {
-      font-size: 1em;
+      font-size: $size-h6;
       font-weight: 700;
       margin-bottom: 1em;
     }
@@ -176,7 +176,7 @@
 
   main {
     h2 {
-      font-size: 1.3em;
+      font-size: $size-h5;
       font-weight: 700;
     }
 
@@ -220,6 +220,17 @@
   max-height: 32px;
   width: 32px;
   border-radius: 32px;
+}
+
+// Data earns the mono voice back explicitly now that .home-page no longer
+// blankets the whole page in it (see #234): scientific/taxonomic names and
+// the field values/labels on a species page.
+.scientific-name {
+  font-family: $family-monospace;
+}
+
+.fieldItem {
+  font-family: $family-monospace;
 }
 
 .fieldItem.edit {

--- a/app/assets/javascripts/sections/_fonts.scss
+++ b/app/assets/javascripts/sections/_fonts.scss
@@ -1,0 +1,75 @@
+// Self-hosted webfonts, bundled from the @fontsource packages through the
+// existing webpack pipeline (see the woff2/woff file-loader rule in
+// config/webpack/webpack.config.js). Nothing is fetched from a third-party
+// origin: no Google Fonts <link>/@import, no render-blocking cross-origin
+// request (see #234).
+//
+// Public Sans carries body copy, headings and UI text. Roboto Mono stays for
+// code samples, scientific names and data values/labels ($family-monospace,
+// sections/_variables.scss).
+
+@font-face {
+  font-family: 'Public Sans';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url('@fontsource/public-sans/files/public-sans-latin-400-normal.woff2') format('woff2'),
+       url('@fontsource/public-sans/files/public-sans-latin-400-normal.woff') format('woff');
+}
+@font-face {
+  font-family: 'Public Sans';
+  font-style: normal;
+  font-weight: 500;
+  font-display: swap;
+  src: url('@fontsource/public-sans/files/public-sans-latin-500-normal.woff2') format('woff2'),
+       url('@fontsource/public-sans/files/public-sans-latin-500-normal.woff') format('woff');
+}
+@font-face {
+  font-family: 'Public Sans';
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+  src: url('@fontsource/public-sans/files/public-sans-latin-600-normal.woff2') format('woff2'),
+       url('@fontsource/public-sans/files/public-sans-latin-600-normal.woff') format('woff');
+}
+@font-face {
+  font-family: 'Public Sans';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url('@fontsource/public-sans/files/public-sans-latin-700-normal.woff2') format('woff2'),
+       url('@fontsource/public-sans/files/public-sans-latin-700-normal.woff') format('woff');
+}
+
+@font-face {
+  font-family: 'Roboto Mono';
+  font-style: normal;
+  font-weight: 300;
+  font-display: swap;
+  src: url('@fontsource/roboto-mono/files/roboto-mono-latin-300-normal.woff2') format('woff2'),
+       url('@fontsource/roboto-mono/files/roboto-mono-latin-300-normal.woff') format('woff');
+}
+@font-face {
+  font-family: 'Roboto Mono';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url('@fontsource/roboto-mono/files/roboto-mono-latin-400-normal.woff2') format('woff2'),
+       url('@fontsource/roboto-mono/files/roboto-mono-latin-400-normal.woff') format('woff');
+}
+@font-face {
+  font-family: 'Roboto Mono';
+  font-style: normal;
+  font-weight: 500;
+  font-display: swap;
+  src: url('@fontsource/roboto-mono/files/roboto-mono-latin-500-normal.woff2') format('woff2'),
+       url('@fontsource/roboto-mono/files/roboto-mono-latin-500-normal.woff') format('woff');
+}
+@font-face {
+  font-family: 'Roboto Mono';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url('@fontsource/roboto-mono/files/roboto-mono-latin-700-normal.woff2') format('woff2'),
+       url('@fontsource/roboto-mono/files/roboto-mono-latin-700-normal.woff') format('woff');
+}

--- a/app/assets/javascripts/sections/_home.scss
+++ b/app/assets/javascripts/sections/_home.scss
@@ -66,7 +66,7 @@
 }
 
 a.navbar-item {
-  font-family: 'Source Sans Pro', BlinkMacSystemFont, -apple-system, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
+  font-family: $family-primary;
   font-weight: 600;
 
   i, .svg-inline--fa {
@@ -140,7 +140,7 @@ a.navbar-item.aligned-item {
 
   main {
     h2 {
-      font-size: 1.3em;
+      font-size: $size-h5;
       font-weight: 700;
     }
 
@@ -182,8 +182,6 @@ a.navbar-item.aligned-item {
 }
 
 .home-page {
-
-  font-family: $family-monospace;
 
   .section.content {
     border-left: 2px solid transparent;

--- a/app/assets/javascripts/sections/_variables.scss
+++ b/app/assets/javascripts/sections/_variables.scss
@@ -1,5 +1,28 @@
 
-$family-monospace: 'Roboto Mono', monospace;
+// Readable sans for body copy, headings and UI text (self-hosted, see
+// sections/_fonts.scss). Mono stays reserved for code, scientific names and
+// data values/labels (see #234).
+$family-sans: 'Public Sans', BlinkMacSystemFont, -apple-system, "Segoe UI", "Helvetica Neue", Helvetica, Arial, sans-serif;
+$family-monospace: 'Roboto Mono', SFMono-Regular, Consolas, Menlo, monospace;
+
+$family-primary: $family-sans;
+$family-secondary: $family-sans;
+// Drives Bulma's own <code>/<pre>/<kbd> styling (base/generic.sass) — this is
+// how "code samples" stay mono without us re-declaring it per selector.
+$family-code: $family-monospace;
+
+// The h1-h6/body/small scale, defined once instead of the ad-hoc px/em values
+// that used to be sprinkled across sections/*.scss (see #234). Values mirror
+// Bulma's own $size-1.."$size-7", but are declared independently since these
+// variables are set before Bulma is imported below.
+$size-h1: 3rem;
+$size-h2: 2.5rem;
+$size-h3: 2rem;
+$size-h4: 1.5rem;
+$size-h5: 1.25rem;
+$size-h6: 1rem;
+$size-small: 0.75rem;
+
 $kelly-green: #41b913ff;
 $deep-taupe: #795c5fff;
 $burlywood: #d9b26fff;

--- a/app/views/explore/genus/_genus_header.html.erb
+++ b/app/views/explore/genus/_genus_header.html.erb
@@ -13,7 +13,7 @@
     </div>
     <div class="column is-9">
           <div class="container">
-            <h1 class="title is-1">
+            <h1 class="title is-1 scientific-name">
               <%= genus.name %>
             </h1>
             <h2 class="subtitle">

--- a/app/views/explore/species/_species_header.html.erb
+++ b/app/views/explore/species/_species_header.html.erb
@@ -14,7 +14,7 @@
     </div>
     <div class="column is-9">
           <div class="container">
-            <h1 class="title is-1">
+            <h1 class="title is-1 scientific-name">
               <%= species.scientific_name %>
             </h1>
             <h2 class="subtitle">

--- a/app/views/explore/species/_species_item.html.erb
+++ b/app/views/explore/species/_species_item.html.erb
@@ -1,7 +1,7 @@
 <%= link_to explore_species_path(species), class: 'species-grid-item' do %>
   <aside><%= species_photo_tag(species, css_class: 'species-grid-item-photo') %></aside>
   <main>
-    <h2 class="title is-5">
+    <h2 class="title is-5 scientific-name">
 
         <% if species.edible? %>
           <span class="icon has-text-success is-small" title="Edible species">

--- a/app/views/explore/species/_species_menu.html.erb
+++ b/app/views/explore/species/_species_menu.html.erb
@@ -1,5 +1,5 @@
 <aside class="menu">
-    <p class="menu-label"><%= species.scientific_name %></p>
+    <p class="menu-label scientific-name"><%= species.scientific_name %></p>
     <ul class="menu-list sticky-menu">
       <li>
         <%= link_to('Informations', explore_species_path(species, anchor: 'specifications'), class: (active == 'informations' ? 'is-active' : '')) %>

--- a/app/views/explore/species/show.html.erb
+++ b/app/views/explore/species/show.html.erb
@@ -40,7 +40,7 @@
           <div class="columns is-multiline">
             <% @species.synonyms.each do |s| %>
               <div class="synonym-item column is-12">
-                <h3 class="title is-5"><%= s.name %> <small><i><%= s.author || 'Unknown author' %></i></small></h1>
+                <h3 class="title is-5 scientific-name"><%= s.name %> <small><i><%= s.author || 'Unknown author' %></i></small></h3>
                 <%
 =begin%>
  <% s.foreign_sources_plants.each do |fo| %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,8 +13,6 @@
   <link rel="manifest" href="/site.webmanifest">
   <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#41b913">
   <link rel="preconnect" href="https://www.googletagmanager.com">
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="preconnect" href="https://bs.plantnet.org">
   <link rel="preconnect" href="https://d2seqvvyy3b8p2.cloudfront.net">
   <link rel="preconnect" href="https://cdn.rawgit.com">

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
     "@babel/core": "^7.20.5",
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-react": "^7.18.6",
+    "@fontsource/public-sans": "^5.3.0",
+    "@fontsource/roboto-mono": "^5.3.0",
     "@rails/ujs": ">= 6.0.3-1",
     "autobind-decorator": ">= 2.4.0",
     "axios": ">= 1.15.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1071,6 +1071,16 @@
   dependencies:
     "@floating-ui/core" "^1.0.3"
 
+"@fontsource/public-sans@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@fontsource/public-sans/-/public-sans-5.3.0.tgz#aa038717a4dede53ad69a1766c5e8d18a8100e19"
+  integrity sha512-kjODI0S3zdv0mBYCIQ8TbBayaiqszpc2UbhJiO3bjIqVVXzcWfHSt2o3WBCLOY3juaGaQoy4MoWCcgmfI5hCuA==
+
+"@fontsource/roboto-mono@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@fontsource/roboto-mono/-/roboto-mono-5.3.0.tgz#de1c58d490a42853389caeca05376ecdb295e7e3"
+  integrity sha512-yhwplHMHW9dCk+1pZuERfcJe+K3rosGVZEoK0XktkxRSqQ9qsipSwwiuW2/8Qmtp9lzu3Ixa/ie4BMH3i8CkZQ==
+
 "@jridgewell/gen-mapping@^0.1.0":
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz#e5d2e450306a9491e3bd77e323e38d7aff315996"


### PR DESCRIPTION
Closes #234

## What
The whole site inherited Roboto Mono through `.home-page`'s ambient `font-family` override — that wrapper class covers home, profile, species show and genus show content. Bulma's own `$family-primary` was never actually pointed at anything else, so nav/footer only looked sans by accident (an unloaded `'Source Sans Pro'` fallback stack).

- Self-host **Public Sans** (body copy, headings, UI text) and **Roboto Mono** (code, scientific names, data values/labels) via `@fontsource`, bundled through the existing webpack `file-loader` rule for woff2/woff. Dropped the Google Fonts CSS `@import` and its `<link rel="preconnect">` hints — nothing is fetched from a third-party origin anymore (verified against the built and dev-server-served CSS bundle: no `googleapis`/`gstatic` references, 8 self-hosted `@font-face` rules with hashed local URLs).
- Removed `.home-page`'s `font-family: $family-monospace` override; `$family-primary`/`$family-secondary`/`$family-code` now point at the new stacks in `sections/_variables.scss`.
- Added a `.scientific-name` class (species/genus headers, synonym list) and an explicit `.fieldItem` rule so mono survives on scientific names and data values now that the ambient override is gone.
- Defined the h1-h6/body/small scale once as Sass variables (`$size-h1`..`$size-h6`, `$size-small`) and reused them at the couple of call sites that had ad-hoc px/em values. Deliberately **not** a blanket `h1..h6` tag rule — `application.css` is also loaded by the admin back-office (`management/layouts/application.html.erb`), and a global rule would have restyled every scaffolded `<h1>Editing Kingdom</h1>` there. Caught in review, fixed by scoping instead of blanket tag selectors.

Also fixes a pre-existing mismatched closing tag on the synonym heading in `species/show.html.erb` (`<h3 ...><h1>` → `<h3 ...></h3>`), noticed while touching that exact line.

## Verification
- `bundle exec rspec spec/features/ spec/requests/web/explore_spec.rb spec/requests/web/home_spec.rb` — 26 examples, 0 failures.
- `bundle exec rubocop` — 0 offenses.
- `yarn build` (classic Yarn v1, matching CI) — clean build, `application.css` has 8 self-hosted `@font-face` rules, no third-party font references.
- Booted the dev server against the local `trefle_dev` dump and curl-verified the served homepage and a real species show page (`/explore/species/abies-concolor`): no `googleapis`/`gstatic` in the HTML, `.scientific-name` class present on the rendered scientific name heading, `.home-page` no longer carries a `font-family` override in the served CSS.
- Two-axis `/code-review` (standards + spec) run against the diff; its one hard finding (the admin-page blast radius from the blanket heading rule) is fixed in this PR.

Touches: `app/assets/javascripts` (fonts/variables/sections), `app/views/layouts`, `app/views/explore/{species,genus}`, `package.json`/`yarn.lock`.