### PR TITLE
Arbitration: a tie must not overwrite, and rank the curation sources

### DIFF
--- a/config/traits.yml
+++ b/config/traits.yml
@@ -26,11 +26,21 @@ completion:
 sources:
   # Strongest first. Compared case-insensitively against foreign_sources.slug.
   # "community" = human-reviewed corrections (RecordCorrection acceptance).
-  # Unknown sources rank after everything listed here.
+  #
+  # Unknown sources all share the lowest rank, so they tie with each other.
+  # A tie never overwrites a filled column (see Ingester::Species#outranked_for?),
+  # which means an unlisted source can fill a gap but cannot win an argument.
+  # Add a source here to give it a say.
   default_priority:
     - community
     - iucn
     - try
+    # Regional floras: measured, referenced, peer-reviewed. Authoritative for
+    # the flora they cover, which is why they sit above the global aggregators.
+    - flora_iberica
+    - flora_of_north_america
+    - flora_of_china
+    - flora_europaea
     - powo
     - wfo
     - ipni
@@ -40,8 +50,12 @@ sources:
     - tropicos
     - tela-botanica
     - catminat
+    # Dendrological and horticultural compilations: useful, cite their sources,
+    # but secondary to a flora.
+    - treesandshrubsonline
     - eol
     - plantnet
+    - pfaf
     - openfarm
     - wikipedia
 

--- a/lib/ingester/species.rb
+++ b/lib/ingester/species.rb
@@ -270,8 +270,8 @@ module Ingester
           next
         end
 
-        if Traits.filled?(attr, old_value) && outranked_by_stronger_fact?(attr, source)
-          puts "[Ingester][Arbitration] keeping #{attr} (a stronger source claims it, '#{source}' recorded as fact only)"
+        if Traits.filled?(attr, old_value) && outranked_for?(attr, source)
+          puts "[Ingester][Arbitration] keeping #{attr} (another source claims it at least as strongly, '#{source}' recorded as fact only)"
           @species.send("#{attr}=", old_value)
         end
 
@@ -281,14 +281,20 @@ module Ingester
       facts
     end
 
-    def outranked_by_stronger_fact?(attr, source)
+    # Only a *strictly stronger* source may overwrite a filled column. On a tie
+    # the existing value stays and the newcomer is recorded as a conflicting
+    # fact: two sources of equal authority disagreeing must not be settled by
+    # crawl order, which is the silent last-write-wins this system exists to
+    # remove. Unknown sources all share the lowest rank, so they tie by default.
+    # Re-ingesting the *same* source is not affected (handled by superseding).
+    def outranked_for?(attr, source)
       return false unless @species.persisted?
 
       strongest_other = @species.species_facts.active_status.for_attribute(attr)
         .where.not(source: source)
         .min_by {|f| Traits.priority_index(f.source) }
 
-      strongest_other && Traits.priority_index(strongest_other.source) < Traits.priority_index(source)
+      strongest_other && Traits.priority_index(strongest_other.source) <= Traits.priority_index(source)
     end
 
     def persist_facts!

--- a/spec/lib/ingester_arbitration_spec.rb
+++ b/spec/lib/ingester_arbitration_spec.rb
@@ -78,4 +78,37 @@ RSpec.describe 'Ingester source arbitration' do
     expect(species.reload.average_height_cm).to be_nil
   end
 
+  it 'does not let an equally-ranked source overwrite a filled column' do
+    # Two unlisted sources tie at the lowest rank: crawl order must not decide.
+    ingest({ source_flora_iberica: 'a', average_height_value: 1500, average_height_unit: 'cm' })
+    ingest({ source_pfaf: 'b', average_height_value: 2500, average_height_unit: 'cm' })
+
+    expect(species.reload.average_height_cm).to eq(1500)
+
+    values = species.species_facts.active_status.for_attribute('average_height_cm').pluck(:source, :value)
+    expect(values).to contain_exactly(%w[flora_iberica 1500], %w[pfaf 2500])
+  end
+
+  it 'still lets an equally-ranked source fill an empty column' do
+    ingest({ source_pfaf: 'b', average_height_value: 900, average_height_unit: 'cm' })
+
+    expect(species.reload.average_height_cm).to eq(900)
+  end
+
+  it 'lets a ranked source beat a lower-ranked one whatever the order' do
+    ingest({ source_pfaf: 'b', average_height_value: 2500, average_height_unit: 'cm' })
+    ingest({ source_flora_iberica: 'a', average_height_value: 1500, average_height_unit: 'cm' })
+
+    expect(species.reload.average_height_cm).to eq(1500)
+  end
+
+  it 'lets the same source update its own value' do
+    ingest({ source_flora_iberica: 'a', average_height_value: 1500, average_height_unit: 'cm' })
+    ingest({ source_flora_iberica: 'a', average_height_value: 1600, average_height_unit: 'cm' })
+
+    expect(species.reload.average_height_cm).to eq(1600)
+    facts = species.species_facts.for_attribute('average_height_cm').order(:id)
+    expect(facts.map(&:status)).to eq(%w[superseded active])
+  end
+
 end


### PR DESCRIPTION
Found by manually curating a real species rather than by reading the code, which is why it is worth fixing now.

### What happened
Reviewing *Quercus rotundifolia* (top of the work queue: high demand, 16% complete), three sources gave a maximum height:

| source | value |
|---|---|
| Flora Iberica | 15 m |
| Trees and Shrubs Online | 15 m |
| PFAF | 25 m |

**The 25 m won.** None of the three were listed in `traits.yml`, so all three tied at the lowest rank, `outranked_by_stronger_fact?` compared with a strict `<`, and the last write took the column. That is exactly the silent last-write-wins this whole system exists to remove — it had simply moved from "unranked crawler order" to "unranked source order".

### The fix
Only a **strictly stronger** source may overwrite a column that already has a value. On a tie the existing value stays, and the newcomer is still recorded as an active fact, so the disagreement stays visible instead of being resolved by whoever ran last.

Consequences, all intended:
- an unlisted source can **fill a gap** but cannot **win an argument**
- re-ingesting the *same* source still updates normally (that path supersedes, it is not a tie)
- adding a source to `traits.yml` is what gives it a say

### Ranking the curation sources
`traits.yml` now lists the sources this work actually draws on. Regional floras (Flora Iberica, Flora of North America, Flora of China, Flora Europaea) sit **above** the global aggregators for the flora they cover: they are measured, referenced and peer-reviewed, where an aggregator often just relays. Dendrological and horticultural compilations (Trees and Shrubs Online, PFAF) sit below — useful, they cite their sources, but secondary to a flora.

### Verification
- 4 new arbitration specs: tie does not overwrite, tie still fills an empty column, a ranked source wins whatever the ingestion order, same-source update still supersedes
- The *Quercus rotundifolia* scenario replayed from a clean state: the column now keeps 1500, and PFAF's 2500 remains queryable as a conflicting fact
- 805 examples / 0 failures, RuboCop 0, Brakeman 0