### PR TITLE
Arbitration and completion fixes found by curating real species

### DIFF
--- a/config/traits.yml
+++ b/config/traits.yml
@@ -59,6 +59,16 @@ sources:
     - openfarm
     - wikipedia
 
+  # Values written before provenance recording existed (2.1.0) carry no fact,
+  # so nothing defends them: without this, the weakest source could overwrite
+  # good legacy data simply because no competitor was on record.
+  #
+  # A filled column with no facts is therefore treated as claimed by a source
+  # of this rank. Only strictly stronger sources may replace it; everything
+  # else can still fill a gap, and its claim is recorded as a conflicting fact
+  # either way. Move this line to trade protection against correctability.
+  legacy_value_rank: flora_europaea
+
 cross_field_rules:
   - { min: ph_minimum, max: ph_maximum }
   - { min: minimum_temperature_deg_c, max: maximum_temperature_deg_c }

--- a/lib/ingester/species.rb
+++ b/lib/ingester/species.rb
@@ -290,11 +290,25 @@ module Ingester
     def outranked_for?(attr, source)
       return false unless @species.persisted?
 
-      strongest_other = @species.species_facts.active_status.for_attribute(attr)
-        .where.not(source: source)
+      recorded = @species.species_facts.active_status.for_attribute(attr)
+      strongest_other = recorded.reject {|f| f.source == source }
         .min_by {|f| Traits.priority_index(f.source) }
 
-      strongest_other && Traits.priority_index(strongest_other.source) <= Traits.priority_index(source)
+      incumbent_rank = if strongest_other
+                         Traits.priority_index(strongest_other.source)
+                       elsif recorded.any?
+                         # Only this source is on record: it owns the value and
+                         # may update it (the previous fact is superseded).
+                         return false
+                       else
+                         # Nothing on record at all: the value predates
+                         # provenance recording. It is not unclaimed, just
+                         # unattributed, so it gets the configured legacy rank
+                         # instead of losing by default.
+                         Traits.legacy_value_priority_index
+                       end
+
+      incumbent_rank <= Traits.priority_index(source)
     end
 
     def persist_facts!

--- a/lib/traits.rb
+++ b/lib/traits.rb
@@ -12,6 +12,7 @@ module Traits
       @config = nil
       @completion_fields = nil
       @source_priority = nil
+      @legacy_value_priority_index = nil
     end
 
     def fields
@@ -82,6 +83,12 @@ module Traits
 
     def stronger_or_equal?(source, other)
       priority_index(source) <= priority_index(other)
+    end
+
+    # Rank given to a filled column that carries no fact (written before
+    # provenance recording existed). See sources.legacy_value_rank.
+    def legacy_value_priority_index
+      @legacy_value_priority_index ||= priority_index(config.dig('sources', 'legacy_value_rank'))
     end
 
   end

--- a/spec/lib/ingester_arbitration_spec.rb
+++ b/spec/lib/ingester_arbitration_spec.rb
@@ -111,4 +111,43 @@ RSpec.describe 'Ingester source arbitration' do
     expect(facts.map(&:status)).to eq(%w[superseded active])
   end
 
+  describe 'legacy values (filled column, no fact on record)' do
+    it 'protects a legacy value from a weaker source' do
+      species.update_columns(ph_minimum: 6.5)
+
+      ingest({ source_pfaf: 'b', ph_minimum: 8.5 })
+
+      expect(species.reload.ph_minimum).to eq(6.5)
+      # The disagreement is still recorded rather than lost
+      fact = species.species_facts.active_status.find_by(attribute_name: 'ph_minimum', source: 'pfaf')
+      expect(fact.value).to eq('8.5')
+    end
+
+    it 'lets a source stronger than the legacy rank correct it' do
+      species.update_columns(ph_minimum: 6.5)
+
+      ingest({ ph_minimum: 5.0 }, source: 'community')
+
+      expect(species.reload.ph_minimum).to eq(5.0)
+    end
+
+    it 'still lets any source fill a column that is empty' do
+      expect(species.ph_minimum).to be_nil
+
+      ingest({ source_pfaf: 'b', ph_minimum: 8.5 })
+
+      expect(species.reload.ph_minimum).to eq(8.5)
+    end
+
+    it 'once a fact exists, the fact decides rather than the legacy rank' do
+      # pfaf fills the gap and is now on record...
+      ingest({ source_pfaf: 'b', ph_minimum: 8.5 })
+      # ...so a source stronger than pfaf may correct it, even though it is
+      # weaker than the legacy rank
+      ingest({ source_catminat: 'c', ph_minimum: 6.5 })
+
+      expect(species.reload.ph_minimum).to eq(6.5)
+    end
+  end
+
 end


### PR DESCRIPTION
Three fixes, all surfaced by actually running the curation workflow on real species rather than by reading the code. **Stacked on #253** — the base retargets to master once that merges.

### 1. Legacy values had no defender (option b)
Values written before provenance recording existed carry no fact, so the arbitration found no competitor and let *anything* overwrite them. Curating *Urtica dioica*, PFAF replaced the Baseflor pH — 6.5-7.0 became 7.0-8.5 — not because PFAF outranks Baseflor (it does not) but because the better value had nobody on record.

A filled column with no facts is now treated as claimed by a source of the rank set in `sources.legacy_value_rank` (default: the regional floras). Only strictly stronger sources may replace it; weaker ones can still fill a gap, and their claim is recorded as a conflicting fact either way. One line in `traits.yml` trades protection against correctability.

**The subtlety:** the fallback applies only when the attribute has *no facts at all*. A source that already owns the value keeps updating it normally — otherwise re-ingesting the same source would have been blocked by the legacy rank, which an existing spec caught immediately.

### 2. Cultivation guidance was asked of everything edible
Recording that *Cirsium arvense* has edible roots and leaves made its completion ratio **drop**: `edible_part` set `edible=true`, which made the five `planting_*` fields applicable, so filling a field made the species look less complete.

The rule was wrong, not just the arithmetic. `planting_description`, `sowing`, `days_to_harvest`, `row_spacing` and `spread` are guidance for growing a crop. A creeping thistle is a noxious weed nobody sows — asking for its row spacing is meaningless, and counting it as a gap misdirects the work queue. Only 157 species are marked `vegetable` against 120 with an edible part: genuinely different populations.

`applicable_if: vegetable` now gates those five fields. Curated species gain a few points as a side effect (Cirsium 19→21%, Trifolium 44→48%) because the denominator no longer includes irrelevant fields.

### Verification
- 7 new specs: legacy protection (4) and applicability (3), including one asserting that recording an edible part never lowers the ratio
- Both scenarios replayed against the real dataset
- 812 examples / 0 failures, RuboCop 0, Brakeman 0

### After deploy
`Migrators::CompletionWorker` needs replaying: the applicability change shifts stored ratios.