### PR TITLE
Arbitration: give legacy values a rank instead of leaving them defenceless

### DIFF
--- a/config/traits.yml
+++ b/config/traits.yml
@@ -26,11 +26,21 @@ completion:
 sources:
   # Strongest first. Compared case-insensitively against foreign_sources.slug.
   # "community" = human-reviewed corrections (RecordCorrection acceptance).
-  # Unknown sources rank after everything listed here.
+  #
+  # Unknown sources all share the lowest rank, so they tie with each other.
+  # A tie never overwrites a filled column (see Ingester::Species#outranked_for?),
+  # which means an unlisted source can fill a gap but cannot win an argument.
+  # Add a source here to give it a say.
   default_priority:
     - community
     - iucn
     - try
+    # Regional floras: measured, referenced, peer-reviewed. Authoritative for
+    # the flora they cover, which is why they sit above the global aggregators.
+    - flora_iberica
+    - flora_of_north_america
+    - flora_of_china
+    - flora_europaea
     - powo
     - wfo
     - ipni
@@ -40,8 +50,12 @@ sources:
     - tropicos
     - tela-botanica
     - catminat
+    # Dendrological and horticultural compilations: useful, cite their sources,
+    # but secondary to a flora.
+    - treesandshrubsonline
     - eol
     - plantnet
+    - pfaf
     - openfarm
     - wikipedia
 

--- a/config/traits.yml
+++ b/config/traits.yml
@@ -59,6 +59,16 @@ sources:
     - openfarm
     - wikipedia
 
+  # Values written before provenance recording existed (2.1.0) carry no fact,
+  # so nothing defends them: without this, the weakest source could overwrite
+  # good legacy data simply because no competitor was on record.
+  #
+  # A filled column with no facts is therefore treated as claimed by a source
+  # of this rank. Only strictly stronger sources may replace it; everything
+  # else can still fill a gap, and its claim is recorded as a conflicting fact
+  # either way. Move this line to trade protection against correctability.
+  legacy_value_rank: flora_europaea
+
 cross_field_rules:
   - { min: ph_minimum, max: ph_maximum }
   - { min: minimum_temperature_deg_c, max: maximum_temperature_deg_c }

--- a/lib/ingester/species.rb
+++ b/lib/ingester/species.rb
@@ -290,11 +290,25 @@ module Ingester
     def outranked_for?(attr, source)
       return false unless @species.persisted?
 
-      strongest_other = @species.species_facts.active_status.for_attribute(attr)
-        .where.not(source: source)
+      recorded = @species.species_facts.active_status.for_attribute(attr)
+      strongest_other = recorded.reject {|f| f.source == source }
         .min_by {|f| Traits.priority_index(f.source) }
 
-      strongest_other && Traits.priority_index(strongest_other.source) <= Traits.priority_index(source)
+      incumbent_rank = if strongest_other
+                         Traits.priority_index(strongest_other.source)
+                       elsif recorded.any?
+                         # Only this source is on record: it owns the value and
+                         # may update it (the previous fact is superseded).
+                         return false
+                       else
+                         # Nothing on record at all: the value predates
+                         # provenance recording. It is not unclaimed, just
+                         # unattributed, so it gets the configured legacy rank
+                         # instead of losing by default.
+                         Traits.legacy_value_priority_index
+                       end
+
+      incumbent_rank <= Traits.priority_index(source)
     end
 
     def persist_facts!

--- a/lib/ingester/species.rb
+++ b/lib/ingester/species.rb
@@ -270,8 +270,8 @@ module Ingester
           next
         end
 
-        if Traits.filled?(attr, old_value) && outranked_by_stronger_fact?(attr, source)
-          puts "[Ingester][Arbitration] keeping #{attr} (a stronger source claims it, '#{source}' recorded as fact only)"
+        if Traits.filled?(attr, old_value) && outranked_for?(attr, source)
+          puts "[Ingester][Arbitration] keeping #{attr} (another source claims it at least as strongly, '#{source}' recorded as fact only)"
           @species.send("#{attr}=", old_value)
         end
 
@@ -281,14 +281,20 @@ module Ingester
       facts
     end
 
-    def outranked_by_stronger_fact?(attr, source)
+    # Only a *strictly stronger* source may overwrite a filled column. On a tie
+    # the existing value stays and the newcomer is recorded as a conflicting
+    # fact: two sources of equal authority disagreeing must not be settled by
+    # crawl order, which is the silent last-write-wins this system exists to
+    # remove. Unknown sources all share the lowest rank, so they tie by default.
+    # Re-ingesting the *same* source is not affected (handled by superseding).
+    def outranked_for?(attr, source)
       return false unless @species.persisted?
 
       strongest_other = @species.species_facts.active_status.for_attribute(attr)
         .where.not(source: source)
         .min_by {|f| Traits.priority_index(f.source) }
 
-      strongest_other && Traits.priority_index(strongest_other.source) < Traits.priority_index(source)
+      strongest_other && Traits.priority_index(strongest_other.source) <= Traits.priority_index(source)
     end
 
     def persist_facts!

--- a/lib/traits.rb
+++ b/lib/traits.rb
@@ -12,6 +12,7 @@ module Traits
       @config = nil
       @completion_fields = nil
       @source_priority = nil
+      @legacy_value_priority_index = nil
     end
 
     def fields
@@ -82,6 +83,12 @@ module Traits
 
     def stronger_or_equal?(source, other)
       priority_index(source) <= priority_index(other)
+    end
+
+    # Rank given to a filled column that carries no fact (written before
+    # provenance recording existed). See sources.legacy_value_rank.
+    def legacy_value_priority_index
+      @legacy_value_priority_index ||= priority_index(config.dig('sources', 'legacy_value_rank'))
     end
 
   end

--- a/spec/lib/ingester_arbitration_spec.rb
+++ b/spec/lib/ingester_arbitration_spec.rb
@@ -111,4 +111,43 @@ RSpec.describe 'Ingester source arbitration' do
     expect(facts.map(&:status)).to eq(%w[superseded active])
   end
 
+  describe 'legacy values (filled column, no fact on record)' do
+    it 'protects a legacy value from a weaker source' do
+      species.update_columns(ph_minimum: 6.5)
+
+      ingest({ source_pfaf: 'b', ph_minimum: 8.5 })
+
+      expect(species.reload.ph_minimum).to eq(6.5)
+      # The disagreement is still recorded rather than lost
+      fact = species.species_facts.active_status.find_by(attribute_name: 'ph_minimum', source: 'pfaf')
+      expect(fact.value).to eq('8.5')
+    end
+
+    it 'lets a source stronger than the legacy rank correct it' do
+      species.update_columns(ph_minimum: 6.5)
+
+      ingest({ ph_minimum: 5.0 }, source: 'community')
+
+      expect(species.reload.ph_minimum).to eq(5.0)
+    end
+
+    it 'still lets any source fill a column that is empty' do
+      expect(species.ph_minimum).to be_nil
+
+      ingest({ source_pfaf: 'b', ph_minimum: 8.5 })
+
+      expect(species.reload.ph_minimum).to eq(8.5)
+    end
+
+    it 'once a fact exists, the fact decides rather than the legacy rank' do
+      # pfaf fills the gap and is now on record...
+      ingest({ source_pfaf: 'b', ph_minimum: 8.5 })
+      # ...so a source stronger than pfaf may correct it, even though it is
+      # weaker than the legacy rank
+      ingest({ source_catminat: 'c', ph_minimum: 6.5 })
+
+      expect(species.reload.ph_minimum).to eq(6.5)
+    end
+  end
+
 end

--- a/spec/lib/ingester_arbitration_spec.rb
+++ b/spec/lib/ingester_arbitration_spec.rb
@@ -78,4 +78,37 @@ RSpec.describe 'Ingester source arbitration' do
     expect(species.reload.average_height_cm).to be_nil
   end
 
+  it 'does not let an equally-ranked source overwrite a filled column' do
+    # Two unlisted sources tie at the lowest rank: crawl order must not decide.
+    ingest({ source_flora_iberica: 'a', average_height_value: 1500, average_height_unit: 'cm' })
+    ingest({ source_pfaf: 'b', average_height_value: 2500, average_height_unit: 'cm' })
+
+    expect(species.reload.average_height_cm).to eq(1500)
+
+    values = species.species_facts.active_status.for_attribute('average_height_cm').pluck(:source, :value)
+    expect(values).to contain_exactly(%w[flora_iberica 1500], %w[pfaf 2500])
+  end
+
+  it 'still lets an equally-ranked source fill an empty column' do
+    ingest({ source_pfaf: 'b', average_height_value: 900, average_height_unit: 'cm' })
+
+    expect(species.reload.average_height_cm).to eq(900)
+  end
+
+  it 'lets a ranked source beat a lower-ranked one whatever the order' do
+    ingest({ source_pfaf: 'b', average_height_value: 2500, average_height_unit: 'cm' })
+    ingest({ source_flora_iberica: 'a', average_height_value: 1500, average_height_unit: 'cm' })
+
+    expect(species.reload.average_height_cm).to eq(1500)
+  end
+
+  it 'lets the same source update its own value' do
+    ingest({ source_flora_iberica: 'a', average_height_value: 1500, average_height_unit: 'cm' })
+    ingest({ source_flora_iberica: 'a', average_height_value: 1600, average_height_unit: 'cm' })
+
+    expect(species.reload.average_height_cm).to eq(1600)
+    facts = species.species_facts.for_attribute('average_height_cm').order(:id)
+    expect(facts.map(&:status)).to eq(%w[superseded active])
+  end
+
 end


### PR DESCRIPTION
Option (b) of the three you were offered. Was stacked on #253, now merged to master, so this targets master directly.

### The problem
Values written before provenance recording existed (everything predating 2.1.0, so effectively the whole database) carry no fact. The arbitration compares facts, so it found no competitor and let *anything* overwrite them.

Curating *Urtica dioica*, PFAF replaced the Baseflor pH — 6.5-7.0 became 7.0-8.5 — not because PFAF outranks Baseflor (it does not), but because the better value had nobody on record to defend it.

### The fix
A filled column with no facts is now treated as claimed by a source of the rank set in `sources.legacy_value_rank`, defaulting to the regional floras. So:

- **only strictly stronger sources** (community, IUCN, TRY, the floras) may replace a legacy value
- everything weaker can still **fill a gap**, it just cannot win an argument
- either way the claim is recorded as a fact, so the disagreement stays visible and queryable

It is one line in `traits.yml` to trade protection against correctability. Moving it down lets more sources correct legacy data; moving it up locks it to human review.

### The subtlety worth knowing
The fallback applies **only when the attribute has no facts at all**. A source that already owns the value keeps updating it normally — otherwise re-ingesting the same source would have been blocked by the legacy rank, which an existing spec caught immediately.

### Verification
- 4 new specs: legacy protected from a weaker source, correctable by a stronger one, gaps still fillable, and facts taking over from the legacy rank once one exists
- The *Urtica dioica* scenario replayed: pH stays 6.5-7.0, PFAF's claim still recorded as a conflicting fact
- 809 examples / 0 failures, RuboCop 0, Brakeman 0

---
Replaces #254, which GitHub auto-closed when its stacked base branch (`arbitration-ties-and-curation-sources`, merged as #253) was deleted. Same branch (`legacy-value-rank`), now targeting `master` directly.
