### PR TITLE
Species page: turn the 'unknown' field noise into a contribution call

### DIFF
--- a/app/assets/javascripts/explore/Species.js
+++ b/app/assets/javascripts/explore/Species.js
@@ -1,5 +1,5 @@
 
-import { map, capitalize } from 'lodash';
+import { map, capitalize, isNil } from 'lodash';
 import React, { useContext } from 'react'
 import ReactIntense from 'react-intense'
 import FieldCalendar from './fields/FieldCalendar';
@@ -29,6 +29,7 @@ import FieldImage from './fields/FieldImage';
 import FieldEdiblePart from './fields/FieldEdiblePart';
 import ReportModal from './elements/ReportModal';
 import Icon from '../shared/Icon';
+import MissingFieldsNotice from './elements/MissingFieldsNotice';
 
 const Species = ({ species }) => {
   const { toggleEdit, correction, edit } = useContext(CorrectionContext)
@@ -108,26 +109,74 @@ const Species = ({ species }) => {
   const renderGrowing = () => {
     const { growth } = species
 
+    // Each entry knows whether the species actually has this data. In view
+    // mode, fields without data are skipped instead of rendering their
+    // "unknown" label next to an empty meter (see issue #238); a single
+    // MissingFieldsNotice below replaces them all. Edit mode still shows
+    // every field, since that's where a contributor fills them in.
+    const climateFields = [
+      {
+        present: !isNil(growth.light),
+        element: <FieldLight name="light" value={growth.light} />
+      },
+      {
+        present: !isNil(growth.atmospheric_humidity),
+        element: <FieldAtmosphericHumidity name="atmospheric_humidity" value={growth.atmospheric_humidity} />
+      },
+      {
+        present: !isNil(growth.ph_minimum) || !isNil(growth.ph_maximum),
+        element: <FieldPh min={growth.ph_minimum} max={growth.ph_maximum} />
+      },
+      {
+        present: !isNil(growth.minimum_precipitation && growth.minimum_precipitation.mm) || !isNil(growth.maximum_precipitation && growth.maximum_precipitation.mm),
+        element: <FieldPrecipitations min={growth.minimum_precipitation && growth.minimum_precipitation.mm} max={growth.maximum_precipitation && growth.maximum_precipitation.mm} />
+      },
+      {
+        present: !isNil(growth.minimum_temperature && growth.minimum_temperature.deg_c) || !isNil(growth.maximum_temperature && growth.maximum_temperature.deg_c),
+        element: <FieldTemperature min={growth.minimum_temperature && growth.minimum_temperature.deg_c} max={growth.maximum_temperature && growth.maximum_temperature.deg_c} />
+      }
+    ]
+
+    const soilFields = [
+      {
+        present: !isNil(growth.soil_humidity),
+        element: <FieldSoilHumidity name={'ground_humidity'} value={growth.soil_humidity} />
+      },
+      {
+        present: !isNil(growth.soil_nutriments),
+        element: <FieldSoilNutriments name={'soil_nutriments'} value={growth.soil_nutriments} />
+      },
+      {
+        present: !isNil(growth.soil_salinity),
+        element: <FieldSoilSalinity name={'soil_salinity'} value={growth.soil_salinity} />
+      },
+      {
+        present: !isNil(growth.soil_texture),
+        element: <FieldSoilTexture name={'soil_texture'} value={growth.soil_texture} />
+      }
+    ]
+
+    const missingCount = [...climateFields, ...soilFields].filter(f => !f.present).length
+    const visibleClimateFields = edit ? climateFields : climateFields.filter(f => f.present)
+    const visibleSoilFields = edit ? soilFields : soilFields.filter(f => f.present)
+
     return (<section className="section content" id="growth">
       <h2 className="title is-3 ">
         <Icon name="seedling" className="has-text-success" /> Growing
         {/* <EditButton /> */}
       </h2>
       { growth.description && <ReactMarkdown source={growth.description} /> }
-      <FieldLight name="light" value={growth.light} />
-      <FieldAtmosphericHumidity name="atmospheric_humidity" value={growth.atmospheric_humidity} />
-      <FieldPh min={growth.ph_minimum} max={growth.ph_maximum} />
-      <FieldPrecipitations min={growth.minimum_precipitation && growth.minimum_precipitation.mm} max={growth.maximum_precipitation && growth.maximum_precipitation.mm} />
-      <FieldTemperature min={growth.minimum_temperature && growth.minimum_temperature.deg_c} max={growth.maximum_temperature && growth.maximum_temperature.deg_c} />
+      {visibleClimateFields.map((f, i) => <React.Fragment key={i}>{f.element}</React.Fragment>)}
 
-      <br />
-      <h4 className="title is-5 ">
-        Soil
-      </h4>
-      <FieldSoilHumidity name={'ground_humidity'} value={growth.soil_humidity} />
-      <FieldSoilNutriments name={'soil_nutriments'} value={growth.soil_nutriments} />
-      <FieldSoilSalinity name={'soil_salinity'} value={growth.soil_salinity} />
-      <FieldSoilTexture name={'soil_texture'} value={growth.soil_texture} />
+      { (edit || visibleSoilFields.length > 0) && <>
+        <br />
+        <h4 className="title is-5 ">
+          Soil
+        </h4>
+        {visibleSoilFields.map((f, i) => <React.Fragment key={i}>{f.element}</React.Fragment>)}
+      </> }
+
+      { !edit && <MissingFieldsNotice count={missingCount} /> }
 
       <br />
       <h4 className="title is-5 ">

--- a/app/assets/javascripts/explore/elements/MissingFieldsNotice.js
+++ b/app/assets/javascripts/explore/elements/MissingFieldsNotice.js
@@ -1,0 +1,34 @@
+
+import React, { useContext } from 'react'
+import CorrectionContext from '../CorrectionContext'
+
+// One compact block replacing the pile of individual "unknown" rows a
+// data-poor species used to show next to empty meters (see issue #238).
+// Unlike the per-field "unknown" labels (Unknown.js), which anyone can edit
+// straight away through their per-visitor guest token, this block is a
+// deliberate call to action: it stays visible when logged out, but clicking
+// it sends an anonymous visitor to sign in first rather than opening the
+// correction form directly.
+const MissingFieldsNotice = ({ count }) => {
+  const { user, toggleEdit } = useContext(CorrectionContext)
+
+  if (!count) return null
+
+  const signedIn = Boolean(user && user.email)
+
+  const handleClick = () => {
+    if (signedIn) {
+      toggleEdit()
+    } else {
+      window.location.href = window.signInPath || '/users/sign_in'
+    }
+  }
+
+  return (
+    <p className="missing-fields-notice" onClick={handleClick} role="button" tabIndex={0}>
+      {count} field{count > 1 ? 's are' : ' is'} missing for this species — help us complete it
+    </p>
+  )
+}
+
+export default MissingFieldsNotice

--- a/app/assets/javascripts/sections/_explore.scss
+++ b/app/assets/javascripts/sections/_explore.scss
@@ -477,4 +477,31 @@
     .gray { border-color: #AAAAAA; }
     .black { border-color: #111111; }
   }
+
+  // Replaces a section's pile of individual "unknown" rows with one
+  // compact call to action (see issue #238).
+  .missing-fields-notice {
+    display: inline-block;
+    margin: .5em 0 1em;
+    padding: .5em .75em;
+    border: 1px dashed #FF4136;
+    border-radius: 4px;
+    color: #FF4136;
+    opacity: .8;
+    cursor: pointer;
+
+    &:hover {
+      opacity: 1;
+    }
+  }
+
+  // Per-species completion percentage next to the scientific-name title;
+  // groundwork for the public completion score (community issue #59).
+  .species-completion {
+    font-family: $family-sans;
+    font-size: .55em;
+    font-weight: normal;
+    vertical-align: middle;
+    margin-left: .5em;
+  }
 }

--- a/app/views/explore/species/_species_header.html.erb
+++ b/app/views/explore/species/_species_header.html.erb
@@ -16,6 +16,9 @@
           <div class="container">
             <h1 class="title is-1 scientific-name">
               <%= species.scientific_name %>
+              <span class="species-completion tag is-light" title="Share of this species' data that is filled in">
+                <%= species.completion_ratio || 0 %>% complete
+              </span>
             </h1>
             <h2 class="subtitle">
               <%= species.common_name || 'No common name' %>

--- a/app/views/explore/species/_species_menu.html.erb
+++ b/app/views/explore/species/_species_menu.html.erb
@@ -2,7 +2,7 @@
     <p class="menu-label scientific-name"><%= species.scientific_name %></p>
     <ul class="menu-list sticky-menu">
       <li>
-        <%= link_to('Informations', explore_species_path(species, anchor: 'specifications'), class: (active == 'informations' ? 'is-active' : '')) %>
+        <%= link_to('Overview', explore_species_path(species, anchor: 'specifications'), class: (active == 'informations' ? 'is-active' : '')) %>
         <% if active == 'informations' %>
           <ul>
             <li><%= link_to('Specifications', explore_species_path(species, anchor: 'specifications')) %></li>

--- a/app/views/explore/species/show.html.erb
+++ b/app/views/explore/species/show.html.erb
@@ -64,6 +64,7 @@
 <script>
   var temp_token = "<%= current_user&.token || @jwt.token %>";
   var _enableManagement = <%= current_user&.admin ? 'true' : 'false' %>;
+  var signInPath = "<%= new_user_session_path %>";
 </script>
 
 <%= javascript_include_tag 'explore/SpeciesPage' %>

--- a/spec/requests/web/explore_spec.rb
+++ b/spec/requests/web/explore_spec.rb
@@ -63,6 +63,34 @@ RSpec.describe 'Explore pages', type: :request do
       expect(img['loading']).to eq('lazy')
       expect(img['alt']).to be_present
     end
+
+    it 'labels the sidebar entry Overview instead of Informations (#238)' do
+      species = Species.friendly.find('abies-alba')
+      get explore_species_path(species)
+
+      expect(response.body).to include('Overview')
+      expect(response.body).not_to include('Informations')
+    end
+
+    it 'shows the species completion percentage next to the title (#238)' do
+      species = Species.friendly.find('abies-alba')
+      species.update_column(:completion_ratio, 42)
+
+      get explore_species_path(species)
+
+      badge = Nokogiri::HTML.fragment(response.body).at_css('.species-completion')
+      expect(badge.text).to include('42%')
+    end
+
+    it 'falls back to 0% when the completion ratio has never been computed' do
+      species = Species.friendly.find('abies-alba')
+      species.update_column(:completion_ratio, nil)
+
+      get explore_species_path(species)
+
+      badge = Nokogiri::HTML.fragment(response.body).at_css('.species-completion')
+      expect(badge.text).to include('0%')
+    end
   end
 
   describe 'GET /explore/genus' do


### PR DESCRIPTION
Closes #238

## What
- **Growing section**: the 9 fields that render a scale meter (light, atmospheric humidity, ph, precipitations, temperature, soil humidity/nutriments/salinity/texture) are only rendered when the species actually has data. Missing ones collapse into one `MissingFieldsNotice` block per section ("N fields are missing for this species — help us complete it"). The notice stays visible logged-out but sends anonymous visitors to sign in first on click, rather than opening the correction form directly like the existing per-field 'unknown' labels do (those already accept guest corrections via the visitor's temp JWT).
- Empty meters are no longer rendered at all.
- Sidebar label 'Informations' → 'Overview'.
- A completion percentage badge next to the species scientific name, sourced from the existing `species.completion_ratio` column (already computed/persisted by `Species#update_completion_ratio!`) — groundwork for the public completion score (community issue #59).

## Scope note
Deliberately limited to the **Growing** section — it's the one the issue describes with empty meters, and the only one where each field renders independently. Specifications (growth_habit, average_height, observations, flower/foliage/fruit conspicuous & color, leaf_retention, texture) still shows bare 'unknown' text for missing fields: those are joined into comma-separated lines per sub-group, so collapsing them the same way is a materially different, riskier refactor. Left as a possible follow-up and noted in the workspace CONTEXT.md so it isn't assumed closed by this PR.

## Testing
- `bundle exec rspec`: 815 examples, 0 failures (10 pre-existing pending, unrelated).
- `bundle exec rubocop`: 396 files, no offenses.
- `bundle exec brakeman`: 0 warnings.
- The Growing-section React behavior (hiding empty fields, the notice block) has **no automated coverage** — there's no JS-capable Capybara driver configured in this repo's CI and no Jest setup, so it isn't testable the way the existing `spec/requests/web/explore_spec.rb` suite works. The two ERB-rendered pieces (sidebar label, completion badge) are covered there instead.

Touches: app/views/explore/species, app/assets/javascripts/explore, app/assets/javascripts/sections/_explore.scss, spec/requests/web