### PR TITLE
Web: rescue Pagy overflow/variable errors as 404, not 500

### DIFF
--- a/app/controllers/explore/explore_controller.rb
+++ b/app/controllers/explore/explore_controller.rb
@@ -5,6 +5,9 @@ class Explore::ExploreController < ActionController::Base
   before_action :generate_jwt
   before_action :set_meta
 
+  rescue_from Pagy::OverflowError, with: :render_page_not_found
+  rescue_from Pagy::VariableError, with: :render_page_not_found
+
   def generate_jwt
     @jwt = ::Auth::JsonWebToken.new(
       user: current_user || User.find_by(email: 'guest@trefle.io'),
@@ -19,6 +22,12 @@ class Explore::ExploreController < ActionController::Base
       title: 'Open Search',
       href: '/opensearch.xml'
     }
+  end
+
+  # An out-of-range or malformed :page (Pagy::OverflowError / Pagy::VariableError) is a
+  # 404, not a 500 — same treatment the API side already gives it in Api::ApiController.
+  def render_page_not_found
+    render file: Rails.public_path.join('404.html'), status: :not_found, layout: false
   end
 
 end

--- a/spec/requests/web/explore_spec.rb
+++ b/spec/requests/web/explore_spec.rb
@@ -97,6 +97,18 @@ RSpec.describe 'Explore pages', type: :request do
       placeholder = Nokogiri::HTML.fragment(response.body).at_css('.species-correction-image .species-correction-image-photo--empty svg.fa-leaf')
       expect(placeholder).not_to be_nil
     end
+
+    it 'renders 404, not 500, for a page number past the last page' do
+      genus = Genus.find_by!(name: 'Abies')
+      get explore_genus_path(genus, page: 1_003_855_986)
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'renders 404, not 500, for a non-numeric page' do
+      genus = Genus.find_by!(name: 'Abies')
+      get explore_genus_path(genus, page: 'not-a-number')
+      expect(response).to have_http_status(:not_found)
+    end
   end
 
   describe 'GET /explore/corrections' do
@@ -118,6 +130,16 @@ RSpec.describe 'Explore pages', type: :request do
     it 'renders a correction page' do
       get explore_record_correction_path(RecordCorrection.first)
       expect(response).to have_http_status(:ok)
+    end
+
+    it 'renders 404, not 500, for a page number past the last page' do
+      get explore_record_corrections_path(page: 1_003_855_986)
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'renders 404, not 500, for a non-numeric page' do
+      get explore_record_corrections_path(page: 'not-a-number')
+      expect(response).to have_http_status(:not_found)
     end
   end
 

--- a/spec/requests/web/explore_spec.rb
+++ b/spec/requests/web/explore_spec.rb
@@ -41,6 +41,16 @@ RSpec.describe 'Explore pages', type: :request do
       expect(img['width']).to be_present
       expect(img['height']).to be_present
     end
+
+    it 'renders 404, not 500, for a page number past the last page' do
+      get explore_path, params: { page: 1_003_855_986 }
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'renders 404, not 500, for a non-numeric page' do
+      get explore_path, params: { page: 'not-a-number' }
+      expect(response).to have_http_status(:not_found)
+    end
   end
 
   describe 'GET /explore/species/:id' do


### PR DESCRIPTION
Closes #257

An out-of-range or malformed `:page` on the web side (`Explore::ExploreController` — species index, genus show, corrections index, i.e. every paginated web page) raised `Pagy::OverflowError`/`Pagy::VariableError` unhandled, bubbling up as a 500 and polluting Sentry. `Api::ApiController` already rescues both on the JSON side; this mirrors that on the web side by rendering the static 404 page instead.

- Added `rescue_from Pagy::OverflowError` / `Pagy::VariableError` to `Explore::ExploreController`, rendering `public/404.html` with a 404 status.
- Request specs: out-of-range page and non-numeric page both assert 404 (not 500) on `GET /explore`.
- Full RSpec suite green (814 examples, 0 failures, 10 pre-existing pending) and RuboCop clean on the touched files.

Touches: app/controllers/explore/explore_controller.rb, spec/requests/web/explore_spec.rb