### PR TITLE
Traits: closed vocabularies, starting with nitrogen_fixation

### DIFF
--- a/config/traits.yml
+++ b/config/traits.yml
@@ -17,6 +17,9 @@
 #   applicable_if:    always (default) | vegetable | edible_or_vegetable — a
 #                     field only counts as "missing" when it is applicable
 #   zero_means_empty: true for bitmask flags / enums where 0 = "not documented"
+#   allowed_values:   closed vocabulary for a free-text column — the ingester
+#                     rejects anything else, so a convention stays a contract
+#                     rather than a habit
 
 version: 1
 
@@ -139,7 +142,10 @@ fields:
   minimum_precipitation_mm: { category: ecology, unit: mm, plausible_range: [0, 15000] }
   maximum_precipitation_mm: { category: ecology, unit: mm, plausible_range: [0, 15000] }
   hardiness_zone: { category: ecology, plausible_range: [1, 13] }
-  nitrogen_fixation: { category: ecology }
+  # Rating scale inherited from USDA PLANTS, where this column originates.
+  # The database held no value at all, so this fixes the vocabulary before
+  # divergent spellings spread.
+  nitrogen_fixation: { category: ecology, allowed_values: [None, Low, Medium, High] }
 
   # --- Cultivation: guidance for growing a crop, so it only counts as missing
   #     for species actually cultivated (vegetable), not for anything that

--- a/lib/checks/plausible_values.rb
+++ b/lib/checks/plausible_values.rb
@@ -5,12 +5,12 @@ module Checks
   class PlausibleValues < Check
 
     def run
-      implausible = implausible_fields
+      implausible = implausible_fields + out_of_vocabulary_fields
       cross = inconsistent_bounds
 
       return if implausible.empty? && cross.empty?
 
-      notes = implausible.map {|n, v| "#{n}=#{v} outside plausible range #{Traits.field(n)['plausible_range']}" }
+      notes = implausible.map {|n, v| "#{n}=#{v.inspect} is not an accepted value" }
       notes += cross.map {|c| "inconsistent bounds: #{c}" }
 
       get_or_create_warning_for_record(
@@ -40,6 +40,18 @@ module Checks
         value = @species.attributes[name]
         next unless value.is_a?(Numeric)
         next if Traits.plausible?(name, value)
+
+        [name, value]
+      end
+    end
+
+    # Free-text columns constrained by a closed vocabulary (allowed_values)
+    def out_of_vocabulary_fields
+      Traits.fields.keys.filter_map do |name|
+        next unless Traits.allowed_values(name)
+
+        value = @species.attributes[name]
+        next if value.nil? || Traits.allowed_value?(name, value)
 
         [name, value]
       end

--- a/lib/ingester/species.rb
+++ b/lib/ingester/species.rb
@@ -270,6 +270,14 @@ module Ingester
           next
         end
 
+        unless Traits.allowed_value?(attr, new_value)
+          @species.send("#{attr}=", old_value)
+          facts << { attribute_name: attr, source: source, value: new_value,
+                     status: :rejected,
+                     notes: "outside the allowed vocabulary #{Traits.allowed_values(attr).inspect}" }
+          next
+        end
+
         if Traits.filled?(attr, old_value) && outranked_for?(attr, source)
           puts "[Ingester][Arbitration] keeping #{attr} (another source claims it at least as strongly, '#{source}' recorded as fact only)"
           @species.send("#{attr}=", old_value)

--- a/lib/traits.rb
+++ b/lib/traits.rb
@@ -68,6 +68,20 @@ module Traits
       value >= range[0] && value <= range[1]
     end
 
+    # Closed vocabulary check for free-text columns (allowed_values). Fields
+    # without one accept anything; nil is handled by filled?, not here.
+    def allowed_value?(name, value)
+      allowed = field(name)&.dig('allowed_values')
+      return true unless allowed
+      return true if value.nil?
+
+      allowed.map(&:to_s).include?(value.to_s)
+    end
+
+    def allowed_values(name)
+      field(name)&.dig('allowed_values')
+    end
+
     def cross_field_rules
       config['cross_field_rules'] || []
     end

--- a/spec/lib/ingester_arbitration_spec.rb
+++ b/spec/lib/ingester_arbitration_spec.rb
@@ -150,4 +150,33 @@ RSpec.describe 'Ingester source arbitration' do
     end
   end
 
+  describe 'closed vocabularies (allowed_values)' do
+    it 'accepts a value from the vocabulary' do
+      ingest({ source_usda: 'x', nitrogen_fixation: 'High' })
+
+      expect(species.reload.nitrogen_fixation).to eq('High')
+    end
+
+    it 'rejects a value outside the vocabulary without assigning it' do
+      ingest({ source_pfaf: 'x', nitrogen_fixation: 'very high' })
+
+      expect(species.reload.nitrogen_fixation).to be_nil
+      fact = species.species_facts.find_by(attribute_name: 'nitrogen_fixation')
+      expect(fact.status).to eq('rejected')
+      expect(fact.notes).to include('allowed vocabulary')
+    end
+
+    it 'is case-sensitive, so spelling drift is caught rather than absorbed' do
+      ingest({ source_pfaf: 'x', nitrogen_fixation: 'high' })
+
+      expect(species.reload.nitrogen_fixation).to be_nil
+    end
+
+    it 'leaves unconstrained text fields alone' do
+      ingest({ source_pfaf: 'x', growth_habit: 'Forb/herb' })
+
+      expect(species.reload.growth_habit).to eq('Forb/herb')
+    end
+  end
+
 end


### PR DESCRIPTION
Answers the open question from curation: what values should `nitrogen_fixation` take?

### Why this rather than just picking one
The column held **no value on any of the 489k species**, so curating white clover meant establishing a convention. Writing `High` and moving on would have left the convention living in a commit message — and the next contributor writes `high`, then `very high`, and the field becomes unqueryable.

### What it does
`allowed_values` does for free-text columns what `plausible_range` already does for numbers:

- the ingester refuses a non-conforming value and records the attempt as a **rejected fact**, so the attempt stays auditable
- `Checks::PlausibleValues` flags values *already in the database* that do not conform, so drift surfaces in the quality sweep
- fields without the key are unconstrained — nothing else in the contract changes

`nitrogen_fixation: [None, Low, Medium, High]`, the rating scale from USDA PLANTS where the column originates.

The check is **case-sensitive on purpose**. `high` is drift, and absorbing it silently is how a vocabulary stops being one. A spec pins that behaviour so it is a decision rather than an accident.

### Verification
- 4 new arbitration specs (accepted value, rejected value, case sensitivity, unconstrained fields untouched)
- Exercised against the curated *Trifolium repens*: `High` conforms, a later `tres eleve` is refused and the column keeps its value
- 819 examples / 0 failures, RuboCop 0, Brakeman 0

### Follow-up available
Other free-text columns inherited from USDA (`growth_habit`, `growth_rate`, `growth_form`, `shape_and_orientation`) have de-facto vocabularies in the data — `Forb/herb`, `Graminoid`, `Shrub`… They could get the same treatment, but that needs auditing the existing values first, so it is deliberately not in this PR.