### PR TITLE
Migrators::ImagesFixer: percent-encode non-ASCII URLs before parsing

### DIFF
--- a/lib/migrators/images_fixer.rb
+++ b/lib/migrators/images_fixer.rb
@@ -35,7 +35,14 @@ module Migrators
     end
 
     def self.uri_for(link)
-      link&.gsub(%r{^//}, 'https://')&.gsub('http://', 'https://')&.gsub(' ', '%20')
+      link = link&.gsub(%r{^//}, 'https://')&.gsub('http://', 'https://')&.gsub(' ', '%20')
+      return link if link.nil?
+
+      # Some crawled URLs (POWO asset paths in particular) carry unescaped
+      # non-ASCII characters (accented author names). URI.parse/HTTParty
+      # raise URI::InvalidURIError on those, so percent-encode them here
+      # rather than leaving it to the caller.
+      URI::DEFAULT_PARSER.escape(link, /[^\x00-\x7F]/)
     end
   end
 end

--- a/spec/lib/migrators/images_fixer_spec.rb
+++ b/spec/lib/migrators/images_fixer_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe Migrators::ImagesFixer do
+  describe '.uri_for' do
+    it 'percent-encodes non-ASCII characters so the URL can be parsed by URI' do
+      link = 'https://storage.googleapis.com/powop-assets/neotropikey/' \
+             'Raddiella esenbeckii Calderón & Soderstr. - 1.jpg'
+
+      uri = described_class.uri_for(link)
+
+      expect { URI.parse(uri) }.not_to raise_error
+      expect(uri).to eq(
+        'https://storage.googleapis.com/powop-assets/neotropikey/' \
+        'Raddiella%20esenbeckii%20Calder%C3%B3n%20&%20Soderstr.%20-%201.jpg'
+      )
+    end
+
+    it 'upgrades protocol-relative and http links to https' do
+      expect(described_class.uri_for('//example.org/a.jpg')).to eq('https://example.org/a.jpg')
+      expect(described_class.uri_for('http://example.org/a.jpg')).to eq('https://example.org/a.jpg')
+    end
+
+    it 'returns nil untouched' do
+      expect(described_class.uri_for(nil)).to be_nil
+    end
+  end
+
+  describe '.run' do
+    let(:species) { create(:species) }
+
+    it 'normalizes a non-ASCII main_image_url instead of crashing' do
+      raw_url = 'https://storage.googleapis.com/powop-assets/neotropikey/Calderón.jpg'
+      escaped_url = 'https://storage.googleapis.com/powop-assets/neotropikey/Calder%C3%B3n.jpg'
+      species.update_columns(main_image_url: raw_url)
+      stub_request(:get, escaped_url).to_return(status: 200)
+
+      expect { described_class.run(species.id) }.not_to raise_error
+
+      expect(species.reload.main_image_url).to eq(escaped_url)
+    end
+
+    it 'normalizes a non-ASCII species_image URL instead of crashing' do
+      raw_url = 'https://storage.googleapis.com/powop-assets/neotropikey/Calderón.jpg'
+      escaped_url = 'https://storage.googleapis.com/powop-assets/neotropikey/Calder%C3%B3n.jpg'
+      species.species_images.create!(image_url: raw_url)
+      stub_request(:get, escaped_url).to_return(status: 200)
+
+      expect { described_class.run(species.id) }.not_to raise_error
+
+      expect(species.reload.species_images.first.image_url).to eq(escaped_url)
+    end
+  end
+end


### PR DESCRIPTION
Closes #244

POWO asset paths can carry unescaped accented characters (author names like `Calderón`). `URI.parse`/HTTParty reject those with `URI::InvalidURIError: URI must be ascii only`, so the affected `Migrators::ImagesFixerWorker` job retried forever without ever succeeding.

`Migrators::ImagesFixer.uri_for` now percent-encodes non-ASCII bytes (`URI::DEFAULT_PARSER.escape(link, /[^\\x00-\\x7F]/)`) after its existing protocol/space normalization, so multi-byte UTF-8 characters turn into valid `%XX` sequences (e.g. `ó` → `%C3%B3`) without double-encoding the spaces it already escapes.

Added spec coverage for `uri_for` directly (non-ASCII fixture URL from the crash report, protocol upgrade, nil passthrough) and for `.run` against a stubbed HTTP call, for both `main_image_url` and a `species_images` row.

Did not do the optional data-sweep mentioned in the issue (counting/fixing existing non-ASCII rows) — kept this PR to the crash fix; happy to follow up separately if wanted.

Touches: lib/migrators, spec/lib/migrators

Note: the full local RSpec run has pre-existing failures in `spec/features` and `spec/requests/web/*` unrelated to this change — they're 500s from missing built JS/webpack assets in a fresh worktree checkout (no `public/packs`, `yarn build` needs a prior `yarn install`), not caused by this fix. `spec/lib/migrators`, `spec/workers/migrators`, and the full suite's rubocop pass are green.