### PR TITLE
Show the running version in the site footer

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -44,6 +44,19 @@ module ApplicationHelper
     controller.class.to_s.underscore.starts_with? 'explore/'
   end
 
+  # The release workflow bakes the git tag into the running container as
+  # APP_REVISION (e.g. "v2.0.2"). Local/dev builds have no such tag.
+  def app_revision
+    ENV['APP_REVISION'].presence || 'dev'
+  end
+
+  # Only tagged releases (v*) have a matching GitHub release page to link to.
+  def app_revision_url
+    return nil unless app_revision.match?(/\Av/)
+
+    "https://github.com/treflehq/trefle-api/releases/tag/#{app_revision}"
+  end
+
   def active_class_for(active_controller: nil, class_name: 'has-text-link')
     cname = "#{controller.class.to_s.underscore.gsub('_controller', '')}##{action_name}"
     puts "cname: #{cname}"

--- a/app/views/layouts/_footer.erb
+++ b/app/views/layouts/_footer.erb
@@ -69,6 +69,14 @@
     </div>
   </nav>
   <div class="container has-text-centered">
-    <p>Trefle is backed by <a target="_blank" rel="noopener noreferrer" href="https://mashum.org">Mashum</a></p>
+    <p>
+      Trefle is backed by <a target="_blank" rel="noopener noreferrer" href="https://mashum.org">Mashum</a>
+      &middot;
+      <% if app_revision_url %>
+        <a class="app-revision" target="_blank" rel="noopener noreferrer" href="<%= app_revision_url %>"><%= app_revision %></a>
+      <% else %>
+        <span class="app-revision"><%= app_revision %></span>
+      <% end %>
+    </p>
   </div>
 </footer>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationHelper, type: :helper do
+  describe '#app_revision' do
+    it 'returns the APP_REVISION env var when set' do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('APP_REVISION').and_return('v2.0.2')
+
+      expect(helper.app_revision).to eq('v2.0.2')
+    end
+
+    it 'falls back to "dev" when unset' do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('APP_REVISION').and_return(nil)
+
+      expect(helper.app_revision).to eq('dev')
+    end
+
+    it 'falls back to "dev" when blank' do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('APP_REVISION').and_return('')
+
+      expect(helper.app_revision).to eq('dev')
+    end
+  end
+
+  describe '#app_revision_url' do
+    it 'links to the GitHub release for a v* tag' do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('APP_REVISION').and_return('v2.0.2')
+
+      expect(helper.app_revision_url).to eq('https://github.com/treflehq/trefle-api/releases/tag/v2.0.2')
+    end
+
+    it 'is nil for the "dev" fallback' do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('APP_REVISION').and_return(nil)
+
+      expect(helper.app_revision_url).to be_nil
+    end
+
+    it 'is nil for a non v* revision' do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('APP_REVISION').and_return('local-build')
+
+      expect(helper.app_revision_url).to be_nil
+    end
+  end
+end

--- a/spec/requests/web/home_spec.rb
+++ b/spec/requests/web/home_spec.rb
@@ -51,4 +51,29 @@ RSpec.describe 'Public website pages', type: :request do
       expect(response).to have_http_status(:ok)
     end
   end
+
+  describe 'Footer app version' do
+    it 'shows the tagged revision linked to its GitHub release' do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('APP_REVISION').and_return('v2.0.2')
+
+      get root_path
+
+      fragment = Nokogiri::HTML.fragment(response.body)
+      link = fragment.at_css('a.app-revision')
+      expect(link.text).to eq('v2.0.2')
+      expect(link['href']).to eq('https://github.com/treflehq/trefle-api/releases/tag/v2.0.2')
+    end
+
+    it 'falls back to "dev" with no link when APP_REVISION is unset' do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('APP_REVISION').and_return(nil)
+
+      get root_path
+
+      fragment = Nokogiri::HTML.fragment(response.body)
+      expect(fragment.at_css('a.app-revision')).to be_nil
+      expect(fragment.at_css('span.app-revision').text).to eq('dev')
+    end
+  end
 end


### PR DESCRIPTION
Closes #245

Renders `ENV['APP_REVISION']` (the git tag baked into the container by the release workflow) next to the "Trefle is backed by" line in the footer, linked to its GitHub release page. Falls back to `dev` with no link for untagged/local builds.

Touches: app/helpers/application_helper.rb, app/views/layouts/_footer.erb, spec/

## Testing
- Full RSpec suite: 823 examples, 0 failures, 10 pending (pre-existing, unrelated)
- RuboCop on changed Ruby files: no offenses
- Brakeman: no warnings