### PR TITLE
Polish the Devise pages: sign in, sign up, forgot/reset password

### DIFF
--- a/app/assets/javascripts/application.scss
+++ b/app/assets/javascripts/application.scss
@@ -100,6 +100,66 @@ span.token.number {
   margin: auto;
 }
 
+// Devise sign in / sign up / password pages (#233): one consistent
+// single-column composition, GitHub OAuth as a proper secondary button
+// instead of a plain-text link, and focus rings that stay visible on
+// keyboard navigation instead of relying on browser/Bulma defaults.
+.auth-oauth-button {
+  background: #24292f;
+  border-color: #24292f;
+  color: #fff;
+
+  .icon {
+    color: inherit;
+  }
+
+  &:hover,
+  &:focus {
+    background: lighten(#24292f, 12%);
+    border-color: lighten(#24292f, 12%);
+    color: #fff;
+  }
+}
+
+.auth-divider {
+  align-items: center;
+  color: #7a7a7a;
+  display: flex;
+  font-size: 0.85rem;
+  margin: 1.5rem 0;
+  text-transform: uppercase;
+
+  &::before,
+  &::after {
+    background: #dbdbdb;
+    content: '';
+    flex: 1;
+    height: 1px;
+  }
+
+  span {
+    padding: 0 0.75rem;
+  }
+}
+
+.auth-links {
+  align-items: center;
+  color: #7a7a7a;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  justify-content: center;
+  margin-top: 1.5rem;
+}
+
+.auth-page a:focus-visible,
+.auth-page .button:focus-visible,
+.auth-page .input:focus-visible,
+.auth-links a:focus-visible {
+  outline: 2px solid $primary;
+  outline-offset: 2px;
+}
+
 .user-image {
   margin-right: 10px;
 }

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -11,41 +11,35 @@
     </div>
   </div>
 </section>
-<div class="columns">
-  <div class="column is-8 is-6-desktop is-offset-2 is-offset-3-desktop">
+<div class="login-container-short auth-page">
 
-    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-    <%= render "devise/shared/error_messages", resource: resource %>
-    <%= f.hidden_field :reset_password_token %>
+  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+  <%= f.hidden_field :reset_password_token %>
 
-    <div class="field">
-      <%= f.label :password, "New password", class: "label" %>
-      <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em>
-      <% end %>
-      <div class="control">
-        <%= f.password_field :password, autofocus: true, autocomplete: "new-password", class: 'input' %>
-      </div>
+  <div class="field">
+    <%= f.label :password, "New password", class: "label" %>
+    <div class="control">
+      <%= f.password_field :password, autofocus: true, autocomplete: "new-password", class: 'input' %>
     </div>
-
-    <div class="field">
-      <%= f.label :password_confirmation, "Confirm new password", class: "label" %>
-      <div class="control">
-        <%= f.password_field :password_confirmation, autocomplete: "new-password", class: 'input' %>
-      </div>
-    </div>
-
-    <div class="columns">
-      <div class="column is-10 is-offset-2">
-        <div class="field is-grouped is-grouped-right">
-          <div class="actions">
-            <%= f.submit "Change my password", class: "button is-primary" %>
-          </div>
-        </div>
-      </div>
-    </div>
+    <% if @minimum_password_length %>
+    <p class="help">(<%= @minimum_password_length %> characters minimum)</p>
     <% end %>
-
-    <%= render "devise/shared/links" %>
   </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation, "Confirm new password", class: "label" %>
+    <div class="control">
+      <%= f.password_field :password_confirmation, autocomplete: "new-password", class: 'input' %>
+    </div>
+  </div>
+
+  <div class="field">
+    <div class="control">
+      <%= f.submit "Change my password", class: "button is-primary is-fullwidth" %>
+    </div>
+  </div>
+  <% end %>
+
+  <%= render "devise/shared/links" %>
 </div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -12,7 +12,7 @@
   </div>
 </section>
 
-<div class="login-container-short">
+<div class="login-container-short auth-page">
 
   <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
@@ -24,13 +24,9 @@
     </div>
   </div>
 
-  <div class="columns">
-    <div class="column is-10 is-offset-2">
-      <div class="field is-grouped is-grouped-right">
-        <div class="actions">
-          <%= f.submit "Send me reset password instructions", class: "button is-primary" %>
-        </div>
-      </div>
+  <div class="field">
+    <div class="control">
+      <%= f.submit "Send me reset password instructions", class: "button is-primary is-fullwidth" %>
     </div>
   </div>
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -11,7 +11,9 @@
     </div>
   </div>
 </section>
-<div class="login-container-short">
+<div class="login-container-short auth-page">
+
+  <%= render "devise/shared/omniauth_providers" %>
 
   <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
@@ -26,32 +28,27 @@
   <div class="field">
     <%= f.label :name, class: "label" %>
     <div class="control">
-      <%= f.text_field :name, autofocus: true, autocomplete: "name", placeholder: 'Your name', class: "input", required: true %>
+      <%= f.text_field :name, autocomplete: "name", placeholder: 'Your name', class: "input", required: true %>
     </div>
   </div>
-
 
   <div class="field">
     <%= f.label :account_type, class: "label" %>
     <div class="control">
-      <div class="select">
-        <%= f.select :account_type, User::ACCOUNT_TYPES.map{|e| [e.to_s.humanize, e]}, autocomplete: "account_type", class: "input, required: true", required: true %>
+      <div class="select is-fullwidth">
+        <%= f.select :account_type, User::ACCOUNT_TYPES.map{|e| [e.to_s.humanize, e]}, {}, autocomplete: "account_type", required: true %>
       </div>
     </div>
   </div>
-
 
   <div class="field">
     <%= f.label :password, class: "label" %>
     <div class="control">
       <%= f.password_field :password, autocomplete: "new-password", class: "input", required: true %>
     </div>
-    <p class="help is-danger">
-      <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em>
-      <% end %>
-    </p>
-
+    <% if @minimum_password_length %>
+    <p class="help">(<%= @minimum_password_length %> characters minimum)</p>
+    <% end %>
   </div>
 
   <div class="field">
@@ -61,23 +58,15 @@
     </div>
   </div>
 
-  <div class="columns">
-    <div class="column is-10 is-offset-2">
-      <div class="field is-grouped is-grouped-right">
-        <div class="actions">
-        <%= recaptcha_tags %>
-        </div>
-      </div>
+  <div class="field">
+    <div class="control">
+      <%= recaptcha_tags %>
     </div>
   </div>
 
-  <div class="columns">
-    <div class="column is-10 is-offset-2">
-      <div class="field is-grouped is-grouped-right">
-        <div class="actions">
-          <%= f.submit "Sign up", class: "button is-primary" %>
-        </div>
-      </div>
+  <div class="field">
+    <div class="control">
+      <%= f.submit "Sign up", class: "button is-primary is-fullwidth" %>
     </div>
   </div>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -11,7 +11,9 @@
     </div>
   </div>
 </section>
-<div class="login-container-short">
+<div class="login-container-short auth-page">
+
+  <%= render "devise/shared/omniauth_providers" %>
 
   <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
 
@@ -22,7 +24,6 @@
     </div>
   </div>
 
-
   <div class="field">
     <%= f.label :password, class: 'label' %>
     <div class="control">
@@ -31,7 +32,6 @@
   </div>
 
   <% if devise_mapping.rememberable? %>
-
   <div class="field">
     <div class="control">
       <%= f.label :remember_me, class: 'checkbox' do %>
@@ -42,14 +42,9 @@
   </div>
   <% end %>
 
-  <div class="columns">
-    <div class="column is-10 is-offset-2">
-      <div class="field is-grouped is-grouped-right">
-
-        <div class="actions">
-          <%= f.submit "Log in", class: "button is-primary" %>
-        </div>
-      </div>
+  <div class="field">
+    <div class="control">
+      <%= f.submit "Log in", class: "button is-primary is-fullwidth" %>
     </div>
   </div>
   <% end %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,39 +1,21 @@
-<footer class="links">
+<footer class="auth-links">
   <%- if controller_name != 'sessions' %>
-  <div class="column">
-    <%= link_to "Log in", new_session_path(resource_name) %>
-  </div>
+  <%= link_to "Log in", new_session_path(resource_name) %>
   <% end %>
 
   <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <div class="column">
-    <%= link_to "Sign up", new_registration_path(resource_name) %>
-  </div>
+  <%= link_to "Sign up", new_registration_path(resource_name) %>
   <% end %>
 
   <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <div class="column">
-    <%= link_to "Forgot your password?", new_password_path(resource_name) %>
-  </div>
+  <%= link_to "Forgot your password?", new_password_path(resource_name) %>
   <% end %>
 
   <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <div class="column">
-    <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %>
-  </div>
+  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %>
   <% end %>
 
   <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <div class="column">
-    <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %>
-  </div>
-  <% end %>
-
-  <%- if devise_mapping.omniauthable? %>
-  <%- resource_class.omniauth_providers.each do |provider| %>
-  <div class="column">
-    <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), method: :post %>
-  </div>
-  <% end %>
+  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %>
   <% end %>
 </footer>

--- a/app/views/devise/shared/_omniauth_providers.html.erb
+++ b/app/views/devise/shared/_omniauth_providers.html.erb
@@ -1,0 +1,12 @@
+<% if devise_mapping.omniauthable? && resource_class.omniauth_providers.any? %>
+  <div class="auth-oauth">
+    <% resource_class.omniauth_providers.each do |provider| %>
+      <%= link_to omniauth_authorize_path(resource_name, provider), method: :post, class: "button is-fullwidth auth-oauth-button" do %>
+        <span class="icon"><%= fa_icon provider, style: :brands, class: 'fa-lg' %></span>
+        <span>Sign in with <%= OmniAuth::Utils.camelize(provider) %></span>
+      <% end %>
+    <% end %>
+  </div>
+
+  <div class="auth-divider"><span>or</span></div>
+<% end %>

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -29,4 +29,24 @@ RSpec.feature 'Sign in/up page', type: :feature do
     expect(page).to have_content 'Signed in successfully'
   end
 
+  scenario 'Sign in page offers GitHub as a proper OAuth button, not a plain link' do
+    visit '/users/sign_in'
+
+    expect(page).to have_css('a.auth-oauth-button', text: 'Sign in with GitHub')
+    expect(page).to have_css('.auth-divider', text: 'or')
+  end
+
+  scenario 'Sign up page offers GitHub as a proper OAuth button, not a plain link' do
+    visit '/users/sign_up'
+
+    expect(page).to have_css('a.auth-oauth-button', text: 'Sign in with GitHub')
+  end
+
+  scenario 'Forgot password page has no GitHub button (it makes no sense there)' do
+    visit '/users/password/new'
+
+    expect(page).to have_no_css('a.auth-oauth-button')
+    expect(page).to have_css('input[type=submit][value="Send me reset password instructions"]')
+  end
+
 end


### PR DESCRIPTION
Closes #233

One consistent single-column composition across the four reachable auth templates (`sessions#new`, `registrations#new`, `passwords#new`/`#edit`): labels above inputs, full-width submit button under the fields, no more nested columns/offsets scaffolding.

- "Sign in with GitHub" becomes a proper dark secondary button with the GitHub mark, above the email form on sign in / sign up, separated by an "or" divider. It no longer appears on unrelated pages (forgot password) where it made no sense.
- `devise/shared/_links` footer links restyled as one consistent inline row instead of stacked blocks with default link styling.
- Two latent bugs fixed while touching these lines: the `account_type` select never received its `autocomplete`/`required` attributes (they landed in the wrong `f.select` argument, so the field had no CSS class either); the password-length hint used the `is-danger` (red) style even though it isn't an error.
- Visible `:focus-visible` outlines on auth-page links/buttons/inputs instead of relying only on browser/Bulma defaults.

Confirmations/unlocks templates are untouched — `:confirmable`/`:lockable` aren't enabled on `User`, so those routes/views are dead code.

## Testing

- New feature spec scenarios cover the GitHub button/divider and its absence on the password reset page.
- Full RSpec suite: 828 examples, 0 failures, 10 pre-existing pending (unrelated `not_yet_implemented` placeholders).
- `bundle exec rubocop`: 396 files inspected, no offenses.
- `bundle exec brakeman -w2`: 0 security warnings.

Touches: app/views/devise, app/assets/javascripts/application.scss, spec/features/sign_in_spec.rb