### PR TITLE
Facts readability and check-message precision

### DIFF
--- a/lib/checks/plausible_values.rb
+++ b/lib/checks/plausible_values.rb
@@ -5,17 +5,20 @@ module Checks
   class PlausibleValues < Check
 
     def run
-      implausible = implausible_fields + out_of_vocabulary_fields
+      problems = implausible_fields + out_of_vocabulary_fields
       cross = inconsistent_bounds
 
-      return if implausible.empty? && cross.empty?
+      return if problems.empty? && cross.empty?
 
-      notes = implausible.map {|n, v| "#{n}=#{v.inspect} is not an accepted value" }
+      # Each problem carries its own reason: whoever triages this warning needs
+      # to know which bound or which vocabulary was violated, not just that
+      # something was.
+      notes = problems.map {|name, value, reason| "#{name}=#{value.inspect} #{reason}" }
       notes += cross.map {|c| "inconsistent bounds: #{c}" }
 
       get_or_create_warning_for_record(
         notes: notes.join("\n"),
-        correction_json: implausible.to_h {|n, _v| [n, nil] }.to_json
+        correction_json: problems.to_h {|name, _value, _reason| [name, nil] }.to_json
       )
     end
 
@@ -41,7 +44,7 @@ module Checks
         next unless value.is_a?(Numeric)
         next if Traits.plausible?(name, value)
 
-        [name, value]
+        [name, value, "outside the plausible range #{Traits.field(name)['plausible_range'].inspect}"]
       end
     end
 
@@ -53,7 +56,7 @@ module Checks
         value = @species.attributes[name]
         next if value.nil? || Traits.allowed_value?(name, value)
 
-        [name, value]
+        [name, value, "outside the allowed vocabulary #{Traits.allowed_values(name).inspect}"]
       end
     end
 

--- a/lib/ingester/species.rb
+++ b/lib/ingester/species.rb
@@ -262,19 +262,15 @@ module Ingester
       @species.changes.slice(*Traits.completion_fields).each do |attr, (old_value, new_value)|
         next if new_value.nil?
 
-        unless Traits.plausible?(attr, new_value)
-          @species.send("#{attr}=", old_value)
-          facts << { attribute_name: attr, source: source, value: new_value,
-                     status: :rejected,
-                     notes: "implausible: outside #{Traits.field(attr)['plausible_range']}" }
-          next
-        end
+        # Captured before any revert: what the source actually claimed, in a
+        # form a reader can interpret (see #fact_value).
+        claimed = fact_value(attr, new_value)
 
-        unless Traits.allowed_value?(attr, new_value)
+        rejection = rejection_reason(attr, new_value)
+        if rejection
           @species.send("#{attr}=", old_value)
-          facts << { attribute_name: attr, source: source, value: new_value,
-                     status: :rejected,
-                     notes: "outside the allowed vocabulary #{Traits.allowed_values(attr).inspect}" }
+          facts << { attribute_name: attr, source: source, value: claimed,
+                     status: :rejected, notes: rejection }
           next
         end
 
@@ -283,7 +279,7 @@ module Ingester
           @species.send("#{attr}=", old_value)
         end
 
-        facts << { attribute_name: attr, source: source, value: new_value, status: :active }
+        facts << { attribute_name: attr, source: source, value: claimed, status: :active }
       end
 
       facts
@@ -317,6 +313,26 @@ module Ingester
                        end
 
       incumbent_rank <= Traits.priority_index(source)
+    end
+
+    # Why a value must not be stored, or nil if it may be.
+    def rejection_reason(attr, value)
+      return "implausible: outside #{Traits.field(attr)['plausible_range']}" unless Traits.plausible?(attr, value)
+      return "outside the allowed vocabulary #{Traits.allowed_values(attr).inspect}" unless Traits.allowed_value?(attr, value)
+
+      nil
+    end
+
+    # A bitmask column stores an integer that means nothing on its own: a fact
+    # recording bloom_months = 28 is unreadable, and the meaning would shift if
+    # the flag order ever changed. Record the flag names instead, so the
+    # provenance trail stays self-describing.
+    def fact_value(attr, raw_value)
+      current = @species.send(attr)
+      return raw_value unless current.is_a?(ActiveFlag::Value)
+
+      names = current.to_a
+      names.any? ? names.join('|') : raw_value
     end
 
     def persist_facts!

--- a/spec/lib/checks_plausible_values_spec.rb
+++ b/spec/lib/checks_plausible_values_spec.rb
@@ -49,4 +49,31 @@ RSpec.describe Checks::PlausibleValues do
 
     expect(warning.reload).not_to be_pending_change_status
   end
+
+  it 'names the bound that was violated, not just that one was' do
+    species.update_columns(average_height_cm: 999_999)
+    described_class.run(species.id)
+
+    warning = RecordCorrection.find_by(warning_type: 'Checks::PlausibleValues')
+    expect(warning.notes).to include('outside the plausible range')
+    expect(warning.notes).to include('12000')
+  end
+
+  it 'names the vocabulary that was violated' do
+    species.update_columns(nitrogen_fixation: 'very high')
+    described_class.run(species.id)
+
+    warning = RecordCorrection.find_by(warning_type: 'Checks::PlausibleValues')
+    expect(warning.notes).to include('outside the allowed vocabulary')
+    expect(warning.notes).to include('High')
+  end
+
+  it 'drops a value that violates the vocabulary when accepted' do
+    species.update_columns(nitrogen_fixation: 'very high')
+    described_class.run(species.id)
+
+    described_class.new(species.id).accept!(nil)
+
+    expect(species.reload.nitrogen_fixation).to be_nil
+  end
 end

--- a/spec/lib/ingester_arbitration_spec.rb
+++ b/spec/lib/ingester_arbitration_spec.rb
@@ -179,4 +179,34 @@ RSpec.describe 'Ingester source arbitration' do
     end
   end
 
+  describe 'bitmask columns' do
+    it 'records the flag names rather than the raw bitmask' do
+      ingest({ source_flora_iberica: 'a', bloom_months: 'mar|apr|may' })
+
+      fact = species.species_facts.find_by(attribute_name: 'bloom_months')
+      expect(fact.value).to eq('mar|apr|may')
+      # 28 would be the raw value: meaningless on its own, and unstable if the
+      # flag order ever changed
+      expect(fact.value).not_to eq('28')
+      expect(fact.value_numeric).to be_nil
+    end
+
+    it 'records readable names on a rejected claim too' do
+      # edible_part is a flag; feed it through a source that loses arbitration
+      ingest({ source_flora_iberica: 'a', edible_part: 'seeds' })
+      ingest({ source_pfaf: 'b', edible_part: 'roots' })
+
+      pfaf_fact = species.species_facts.find_by(attribute_name: 'edible_part', source: 'pfaf')
+      expect(pfaf_fact.value).to eq('roots')
+    end
+
+    it 'leaves non-flag values untouched' do
+      ingest({ source_flora_iberica: 'a', average_height_value: 250, average_height_unit: 'cm' })
+
+      fact = species.species_facts.find_by(attribute_name: 'average_height_cm')
+      expect(fact.value).to eq('250')
+      expect(fact.value_numeric).to eq(250)
+    end
+  end
+
 end


### PR DESCRIPTION
Reopened against master — the original PR auto-closed when its base branch was deleted on merging #259. Rebased, no conflicts.

Two fixes found by exercising the system the way a user and a maintainer would, rather than from the console.

### 1. Facts recorded raw bitmasks
Querying the facts endpoint as a client showed what it actually returns:

```json
{ "attribute_name": "bloom_months", "value": "28" }
{ "attribute_name": "fruit_months", "value": "1536" }
{ "attribute_name": "edible_part",  "value": "32" }
```

A consumer cannot interpret `28` without reproducing our flag definitions, and the number would mean something else if the flag order ever changed. The species payload already renders these as names, so the two endpoints disagreed about the same data. Facts now store `mar|apr|may`, `oct|nov`, `seeds` — self-describing and stable, with `value_numeric` correctly null instead of a meaningless `28`.

The claimed value is captured **before** any arbitration revert, so a rejected or outranked claim reads as clearly as a winning one — those are the rows someone inspects when investigating a disagreement.

### 2. The check stopped naming what was violated
Adding vocabulary support in #259 collapsed both problem kinds into "X is not an accepted value". That reads fine until someone triages the warning: for a numeric it no longer named the range, which is exactly what tells you whether the *value* or the *range* is wrong. Each detector now carries its own reason.

### Verification
- 6 new specs across both fixes, including one asserting a fact is explicitly *not* `28`
- Re-curated *Quercus rotundifolia* and read it back through `GET /api/v1/species/{id}/facts`
- Exercised the real sweep path (`Checks.run_all`, what the hourly worker calls) end to end on production data: implausible value refused at ingestion → legacy bad value caught by the sweep → `accept!` drops it → re-run produces no duplicate
- 831 examples / 0 failures after rebase, RuboCop 0, Brakeman 0

Also extracts `rejection_reason` — the readable-value capture had pushed the arbitration loop past its length limit.