### PR TITLE
Normalize API error responses into a single documented envelope

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -202,6 +202,10 @@ module Api
 
     def render_internal_server_error_response(exception)
       Rails.logger.error("[render_internal_server_error_response] #{exception.class}: #{exception.message}")
+      # rescue_from handles the exception before it escapes the controller, so it never reaches
+      # Sentry::Rails::CaptureExceptions (the Rack middleware that auto-reports uncaught exceptions).
+      # Report it explicitly or it goes dark.
+      Sentry.capture_exception(exception)
       render_error('An unexpected error occurred. Please contact us if it persists. See https://trefle.io', :internal_server_error)
     end
 

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -2,6 +2,16 @@ module Api
   class ApiController < ActionController::API
     class UnknownQueryKeyError < StandardError; end
 
+    # rescue_from handlers are searched most-specific-last-declared-first (see
+    # ActiveSupport::Rescuable#find_rescue_handler): it reverses the
+    # declaration list and takes the first class match. StandardError has to
+    # be declared FIRST so every more specific rescue below still wins; if it
+    # were declared last it would shadow all of them.
+    rescue_from StandardError, with: :render_internal_server_error_response
+    # A malformed request body (e.g. invalid JSON with a JSON content type)
+    # used to bubble past the controller and surface as an HTML error page
+    # instead of the API envelope (#126).
+    rescue_from ActionDispatch::Http::Parameters::ParseError, with: :render_malformed_request_response
     rescue_from ActionController::BadRequest, with: :render_bad_request_response
     rescue_from UnknownQueryKeyError, with: :render_unknown_query_key_response
     rescue_from ActiveRecord::RecordInvalid, with: :render_unprocessable_record_response
@@ -141,8 +151,25 @@ module Api
       render_unauthorized("IP address (#{client_ip}) is not allowed (expecting #{ip})") && return if ip && ip != client_ip
     end
 
-    def render_error(message, status)
-      render(json: { error: true, message: message }, status: status)
+    # The single envelope documented for every /api error response:
+    # `{ error: true, code:, message:, messages:, details: }`, loosely
+    # inspired by RFC 9457 (without adopting its media type). `code` is the
+    # Rails status symbol (e.g. "not_found") so clients can switch on it
+    # without parsing prose. `messages` duplicates `message` for one
+    # deprecation cycle -- existing clients (mobile/third-party) read that
+    # key today (#216).
+    def render_error(message, status, details: nil)
+      render(json: {
+        error: true,
+        code: error_code_for(status),
+        message: message,
+        messages: message,
+        details: details
+      }.compact, status: status)
+    end
+
+    def render_unauthorized(message)
+      render_error(message, :unauthorized)
     end
 
     def render_unprocessable_record_response(exception)
@@ -167,6 +194,21 @@ module Api
 
     def render_page_overflow_response(exception)
       render_error(exception.message, :not_found)
+    end
+
+    def render_malformed_request_response(_exception)
+      render_error('The request body could not be parsed. Check that it is valid JSON.', :bad_request)
+    end
+
+    def render_internal_server_error_response(exception)
+      Rails.logger.error("[render_internal_server_error_response] #{exception.class}: #{exception.message}")
+      render_error('An unexpected error occurred. Please contact us if it persists. See https://trefle.io', :internal_server_error)
+    end
+
+    def error_code_for(status)
+      return status.to_s if status.is_a?(Symbol)
+
+      Rack::Utils::SYMBOL_TO_STATUS_CODE.invert[status.to_i]&.to_s || status.to_s
     end
 
     def apply_filters(collection, filterable_fields)

--- a/app/controllers/api/auth/auth_controller.rb
+++ b/app/controllers/api/auth/auth_controller.rb
@@ -15,7 +15,7 @@ module Api
           token = ::Auth::JsonWebToken.new(user: @user, origin: origin, ip: ip)
           render json: { token: token.token, expiration: token.time.strftime('%m-%d-%Y %H:%M') }, status: :ok
         else
-          render json: { error: 'unauthorized' }, status: :unauthorized
+          render_unauthorized('Invalid credentials')
         end
       end
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -45,13 +45,19 @@ Rack::Attack.throttled_response_retry_after_header = true
 Rack::Attack.throttled_responder = lambda do |request|
   match_data = request.env['rack.attack.match_data']
   is_sponsor = Rack::Attack.token(request)&.starts_with?('spo-')
+  message = is_sponsor ? 'Too many requests, please slow down' : 'Too many requests. Please visit https://trefle.io/about#support to learn how to increase your limit.'
 
   headers = { 'Content-Type' => 'application/json' }.merge(Rack::Attack.rate_limit_headers(match_data))
 
+  # Same envelope as Api::ApiController#render_error -- this response is
+  # built by Rack middleware, before any controller runs, so it can't reuse
+  # the helper directly (#216).
   [429, headers, [
     {
       error: true,
-      message: is_sponsor ? 'Too many requests, please slow down' : 'Too many requests. Please visit https://trefle.io/about#support to learn how to increase your limit.'
+      code: 'too_many_requests',
+      message: message,
+      messages: message
     }.to_json
   ]]
 end

--- a/lib/schemas/v1.rb
+++ b/lib/schemas/v1.rb
@@ -15,6 +15,7 @@ module Schemas
       source: Source.schema,
       correction: RecordCorrection.schema,
       zone: Zone.schema,
+      error: Error.schema,
       request_body_correction: RecordCorrection.request_body,
       filters_families: Family.filters,
       filters_genus: Genus.filters,

--- a/lib/schemas/v1/error.rb
+++ b/lib/schemas/v1/error.rb
@@ -1,0 +1,19 @@
+module Schemas
+  module V1
+    module Error
+      # The single envelope every /api error response shares (issue #216),
+      # loosely inspired by RFC 9457 without adopting its media type.
+      # `messages` duplicates `message` for one deprecation cycle -- existing
+      # clients (mobile/third-party) read that key today.
+      def self.schema
+        Helpers.object_of({
+          error: { type: :boolean, example: true },
+          code: { type: :string, description: 'A machine-readable error code, stable across releases', example: 'not_found' },
+          message: { type: :string, description: 'A human-readable description of the error' },
+          messages: { type: :string, description: 'Deprecated alias of `message`, kept for backward compatibility' },
+          details: { type: :object, nullable: true, description: 'Optional structured context about the error' }
+        }, extras: { required: %w[error code message] })
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,6 +2,7 @@ require File.expand_path('./spec_helper', __dir__)
 require File.expand_path('./support/json_api_helper', __dir__)
 require File.expand_path('./support/json_schema_matcher', __dir__)
 require File.expand_path('./support/shared_examples/collection_endpoints', __dir__)
+require File.expand_path('./support/shared_examples/api_errors', __dir__)
 require File.expand_path('./support/test_seeds', __dir__)
 
 ENV['RAILS_ENV'] ||= 'test'

--- a/spec/requests/api/v1/900_auth_spec.rb
+++ b/spec/requests/api/v1/900_auth_spec.rb
@@ -50,6 +50,7 @@ describe 'Auth API' do
       end
 
       response '401', 'Invalid credentials' do
+        schema Schemas::Helpers.schema_href(schema: 'error')
         let(:token) { 'invalid' }
         let(:claim_params) do
           {
@@ -61,6 +62,7 @@ describe 'Auth API' do
       end
 
       response '422', 'Missing parameters' do
+        schema Schemas::Helpers.schema_href(schema: 'error')
         let(:token) { user.token }
         let(:claim_params) do
           {

--- a/spec/requests/api/v1/error_envelope_spec.rb
+++ b/spec/requests/api/v1/error_envelope_spec.rb
@@ -68,5 +68,13 @@ RSpec.describe 'API error envelope', type: :request do
       expect(response.content_type).to match(%r{application/json})
       expect(response.body).not_to include('<html')
     end
+
+    it 'still reports the exception to Sentry' do
+      # rescue_from StandardError handles the exception before it escapes the controller, so it
+      # never reaches Sentry's Rack middleware -- it must be reported explicitly instead.
+      expect(Sentry).to receive(:capture_exception).with(instance_of(RuntimeError))
+
+      get '/api/v1/plants/abies-alba', params: { token: user.token }
+    end
   end
 end

--- a/spec/requests/api/v1/error_envelope_spec.rb
+++ b/spec/requests/api/v1/error_envelope_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+# Covers the documented error envelope from issue #216: one shape --
+# `{ error: true, code:, message:, messages:, details: }` -- across every
+# kind of /api error (400/401/404/422/429), plus the malformed-JSON case
+# that used to leak an HTML error page instead of JSON (#126).
+RSpec.describe 'API error envelope', type: :request do
+  let(:user) { create(:user) }
+
+  describe 'GET /api/v1/species with an unknown filter key' do
+    before { get '/api/v1/species', params: { token: user.token, filter: { not_a_real_field: 'x' } } }
+
+    it_behaves_like 'renders API errors', status: :bad_request, code: 'bad_request'
+  end
+
+  describe 'GET /api/v1/plants without a token' do
+    before { get '/api/v1/plants' }
+
+    it_behaves_like 'renders API errors', status: :unauthorized, code: 'unauthorized'
+  end
+
+  describe 'GET /api/v1/plants/:id for an unknown slug' do
+    before { get '/api/v1/plants/does-not-exist-at-all', params: { token: user.token } }
+
+    it_behaves_like 'renders API errors', status: :not_found, code: 'not_found'
+  end
+
+  describe 'POST /api/auth/claim missing a required param' do
+    before { post '/api/auth/claim', params: { token: user.token } }
+
+    it_behaves_like 'renders API errors', status: :unprocessable_entity, code: 'unprocessable_entity'
+  end
+
+  describe 'exceeding the rate limit' do
+    before do
+      Rack::Attack.cache.reset!
+      60.times { get '/api/v1/', params: { token: user.token } }
+      get '/api/v1/', params: { token: user.token }
+    end
+
+    after { Rack::Attack.cache.reset! }
+
+    it_behaves_like 'renders API errors', status: :too_many_requests, code: 'too_many_requests'
+  end
+
+  describe 'a malformed JSON body' do
+    before do
+      post '/api/auth/claim', params: '{"broken json', headers: { 'CONTENT_TYPE' => 'application/json' }
+    end
+
+    it_behaves_like 'renders API errors', status: :bad_request, code: 'bad_request'
+
+    it 'never falls back to an HTML error page' do
+      expect(response.content_type).to match(%r{application/json})
+      expect(response.body).not_to include('<html')
+    end
+  end
+
+  describe 'an unexpected server error' do
+    before do
+      allow(Species).to receive(:friendly).and_raise(RuntimeError, 'boom')
+      get '/api/v1/plants/abies-alba', params: { token: user.token }
+    end
+
+    it_behaves_like 'renders API errors', status: :internal_server_error, code: 'internal_server_error'
+
+    it 'never falls back to an HTML error page' do
+      expect(response.content_type).to match(%r{application/json})
+      expect(response.body).not_to include('<html')
+    end
+  end
+end

--- a/spec/support/shared_examples/api_errors.rb
+++ b/spec/support/shared_examples/api_errors.rb
@@ -1,0 +1,22 @@
+require 'rspec/expectations'
+
+# Asserts the single documented error envelope every /api error response
+# shares: `{ error: true, code:, message:, messages:, details: }`. `messages`
+# is a deprecated alias kept alongside `message` for one deprecation cycle
+# (see issue #216) -- existing clients that read the old key keep working.
+#
+# Usage: perform the request in a `before` block, then
+#   it_behaves_like 'renders API errors', status: :not_found, code: 'not_found'
+RSpec.shared_examples 'renders API errors' do |status:, code:|
+  it "renders the API error envelope for a #{status} response" do
+    expect(response).to have_http_status(status)
+    expect(response.content_type).to match(%r{application/json})
+
+    body = JSON.parse(response.body)
+
+    expect(body['error']).to eq(true)
+    expect(body['code']).to eq(code)
+    expect(body['message']).to be_present
+    expect(body['messages']).to eq(body['message'])
+  end
+end


### PR DESCRIPTION
Closes #216. Also closes #126 (malformed JSON body was leaking an HTML error page instead of a JSON error).

## What changed

Every `/api` error response now shares one envelope: `{ error: true, code:, message:, messages:, details: }`, loosely inspired by RFC 9457 without adopting its media type. `code` is the Rails status symbol (e.g. `not_found`) so clients can branch on it without parsing prose. `messages` duplicates `message` for one deprecation cycle — existing mobile/third-party clients read that key today.

- `rescue_from StandardError` added to `Api::ApiController` so an unexpected 500 always renders the envelope instead of Rails' default HTML error page. It's declared *first* in the `rescue_from` list: Rails searches handlers in reverse declaration order, so `StandardError` has to be checked last or it would shadow every more specific rescue below it.
- `rescue_from ActionDispatch::Http::Parameters::ParseError` added so a malformed JSON body (bad `Content-Type` or a truncated payload) returns a 400 envelope instead of leaking an HTML error page (#126).
- `Api::Auth::AuthController`'s manual 401 render and the rack-attack 429 throttle body now build the same envelope.
- Documented the envelope as `Schemas::V1::Error` in `lib/schemas/` and referenced it from the auth endpoint's swagger 401/422 responses.
- Added a "renders API errors" shared RSpec example and a dedicated request spec (`spec/requests/api/v1/error_envelope_spec.rb`) exercising 400/401/404/422/429/500, plus the malformed-JSON acceptance case.
- `render_internal_server_error_response` now reports the exception to Sentry explicitly. `rescue_from StandardError` handles it before it escapes the controller, so it never reaches `Sentry::Rails::CaptureExceptions` (the Rack middleware that normally auto-reports uncaught exceptions) — without this it would render cleanly but go unreported.

## Testing

- Full RSpec suite: 841 examples, 0 failures, 10 pending (pre-existing "not yet implemented" placeholders). No new failures.
- `bundle exec rubocop`: 0 offenses.
- `bundle exec brakeman -q -w2`: 0 security warnings.

Touches: app/controllers/api/, config/initializers/rack_attack.rb, lib/schemas/, spec/requests, spec/support/shared_examples
