### PR TITLE
Color discipline: one green accent, CTAs that pass WCAG AA

### DIFF
--- a/app/assets/javascripts/application.scss
+++ b/app/assets/javascripts/application.scss
@@ -1,47 +1,11 @@
 
-// 2. Set your own initial variables
-// Update blue
-// $blue: #72d0eb;
-// // Add pink and its invert
-// $pink: #ffb3b3;
-// $pink-invert: #fff;
-// // Add a serif family
-// $family-serif: "Merriweather", "Georgia", serif;
-//
-// // 3. Set the derived variables
-// // Use the new pink as the primary color
-// $primary: $pink;
-// $primary-invert: $pink-invert;
-// // Use the existing orange as the danger color
-// $danger: $orange;
-// // Use the new serif family
-// $family-primary: $family-serif;
-
-// 4. Import the rest of Bulma
+// Brand colors, breakpoints and the respond-to() mixin all live in
+// sections/_variables.scss (imported below) — this used to duplicate them
+// with stale values (a plain Bulma blue $link/$primary that #235 fixed);
+// keep them declared exactly once so the accent family can't drift out of
+// sync again.
 
 @import 'sections/fonts';
-
-$green: #41b913;
-$blue: #3273dc;
-$primary: $green;
-
-$break-small: 480px;
-$break-large: 1024px;
-
-@mixin respond-to($media) {
-  @if $media == handhelds {
-    @media only screen and (max-width: $break-small) { @content; }
-    @media only screen and (max-width: 2 * $break-small) and (-webkit-device-pixel-ratio : 3) { @content; }
-    @media only screen and (max-width: 2 * $break-small) and (-webkit-device-pixel-ratio : 2) { @content; }
-  }
-  @else if $media == medium-screens {
-    @media only screen and (min-width: $break-small + 1) and (max-width: $break-large - 1) { @content; }
-  }
-  @else if $media == wide-screens {
-    @media only screen and (min-width: $break-large) { @content; }
-  }
-}
-
 @import 'sections/variables';
 
 @import 'bulma/bulma';
@@ -152,10 +116,19 @@ span.token.number {
   margin-top: 1.5rem;
 }
 
-.auth-page a:focus-visible,
-.auth-page .button:focus-visible,
-.auth-page .input:focus-visible,
-.auth-links a:focus-visible {
+// Sitewide keyboard-focus ring (#235): Bulma only outlines its own
+// form controls, and only with a soft box-shadow, so plain links, the
+// sidebar menu and footer nav items had nothing to show on :focus.
+// One rule, applied to every interactive element, instead of relying on
+// browser/Bulma defaults or copy-pasting this per section (originally
+// scoped to .auth-page alone, see #233).
+a:focus-visible,
+button:focus-visible,
+.button:focus-visible,
+.input:focus-visible,
+.textarea:focus-visible,
+.select select:focus-visible,
+[tabindex]:focus-visible {
   outline: 2px solid $primary;
   outline-offset: 2px;
 }

--- a/app/assets/javascripts/sections/_home.scss
+++ b/app/assets/javascripts/sections/_home.scss
@@ -45,9 +45,9 @@
   font-size: .7rem;
   padding: 2px 5px;
   margin-left: 1em;
-  border: 1px solid $blue;
+  border: 1px solid $primary;
   background: #fff;
-  color: $blue;
+  color: $primary;
   border-radius: 2px;
   top: -20px;
 

--- a/app/assets/javascripts/sections/_variables.scss
+++ b/app/assets/javascripts/sections/_variables.scss
@@ -23,16 +23,32 @@ $size-h5: 1.25rem;
 $size-h6: 1rem;
 $size-small: 0.75rem;
 
+// Kelly green is the brand mark (logo, favicon/tile meta in
+// layouts/application.html.erb) but white text on it measures 2.03:1 —
+// nowhere near WCAG AA's 4.5:1 for normal text — so it never carries text on
+// its own. Forest green is the one accent used wherever color meets text:
+// links, solid buttons/badges, active pagination/menu state, focus rings
+// (see #235). Bulma darkens it further on hover/active, which only raises
+// the contrast.
 $kelly-green: #41b913ff;
+$forest-green: #1c7a3dff;
 $deep-taupe: #795c5fff;
 $burlywood: #d9b26fff;
 $green-blue-crayola: #1982c4ff;
 $kobi: #ee92c2ff;
 
-$green: $kelly-green;
+$green: $forest-green;
+// Kept as an available semantic color (e.g. a future "info" use), but no
+// longer wired into $link/$primary/focus — Bulma's default blue must not
+// leak back in through those (see #235).
 $blue: $green-blue-crayola;
 
 $primary: $green;
+// Bulma defaults $link to $blue; pin it to the single accent so links, nav
+// hovers, pagination and form focus rings (all derived from $link) share the
+// same green instead of Bulma's blue.
+$link: $green;
+$link-focus-border: $green;
 $menu-item-active-background-color: $green;
 
 $break-small: 480px;

--- a/spec/lib/color_palette_contrast_spec.rb
+++ b/spec/lib/color_palette_contrast_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+# Guards the WCAG AA promise from #235: the brand accent declared in
+# sections/_variables.scss must stay readable everywhere it carries text —
+# as a link/icon color on a white background, and as the fill behind the
+# white text Bulma picks for solid buttons, badges, active pagination and
+# the sidebar's active menu item. Parses the real SCSS file instead of
+# duplicating hex values here, so a future color change that regresses
+# contrast fails this spec instead of silently shipping.
+RSpec.describe 'Color palette contrast' do
+  let(:wcag_aa_normal_text) { 4.5 }
+  let(:variables_path) { Rails.root.join('app/assets/javascripts/sections/_variables.scss') }
+  let(:variables) { parse_scss_variables(variables_path) }
+
+  def parse_scss_variables(path)
+    raw = {}
+    File.readlines(path).each do |line|
+      match = line.match(/^\$([\w-]+):\s*(.+?);/)
+      raw[match[1]] = match[2].strip if match
+    end
+
+    resolved = {}
+    raw.each_key {|name| resolved[name] = resolve_scss_value(name, raw, resolved) }
+    resolved
+  end
+
+  def resolve_scss_value(name, raw, resolved)
+    return resolved[name] if resolved.key?(name)
+
+    value = raw.fetch(name)
+    reference = value.match(/\A\$([\w-]+)\z/)
+    hex = reference ? resolve_scss_value(reference[1], raw, resolved) : value
+
+    hex.delete('#').sub(/f{2}\z/i, '') # 8-digit "…ff" alpha suffix -> plain 6-digit hex
+  end
+
+  def relative_luminance(hex)
+    r, g, b = hex.scan(/../).map {|c| c.to_i(16) / 255.0 }
+    r, g, b = [r, g, b].map {|c| c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055)**2.4 }
+    (0.2126 * r) + (0.7152 * g) + (0.0722 * b)
+  end
+
+  def contrast_ratio(hex_a, hex_b)
+    lighter, darker = [relative_luminance(hex_a), relative_luminance(hex_b)].sort.reverse
+    (lighter + 0.05) / (darker + 0.05)
+  end
+
+  it 'wires $primary, $link and the sidebar active state to the same accent' do
+    expect(variables.fetch('link')).to eq(variables.fetch('primary'))
+    expect(variables.fetch('menu-item-active-background-color')).to eq(variables.fetch('primary'))
+  end
+
+  it 'keeps the accent green readable as text on a white page background' do
+    expect(contrast_ratio(variables.fetch('green'), 'ffffff')).to be >= wcag_aa_normal_text
+  end
+
+  it 'keeps white readable on the accent green fill (buttons, badges, active states)' do
+    expect(contrast_ratio('ffffff', variables.fetch('green'))).to be >= wcag_aa_normal_text
+  end
+end


### PR DESCRIPTION
Closes #235

Bulma's default `$link` stayed blue while `$primary` was the brand kelly green (`#41b913`) — links, nav hovers, pagination and form focus rings rendered blue while buttons/badges/sidebar-active-state were green. Worse, white text on that kelly green measures 2.03:1, well under WCAG AA's 4.5:1 for normal text.

## What changed

- Added `$forest-green` (`#1c7a3d`), an AA-safe shade of the accent, and made it the single color behind `$primary`, `$link` and `$link-focus-border`. Kelly green stays as the brand mark only (logo, favicon/tile meta) since it can't carry text on its own.
- Because Bulma derives nav/menu hovers, pagination, form focus rings and the sidebar's active state from `$link`/`$primary`, this one variable change sweeps all of them. Hover/active states darken further via Bulma's own `bulmaDarken()`, which only improves contrast.
- Generalized the auth-page-only `:focus-visible` outline (#233) to every interactive element sitewide.
- Dropped a dead duplicate `$green`/`$blue`/`$primary` block in `application.scss` that was silently shadowed by `sections/_variables.scss` — one source of truth for the accent now.
- Added `spec/lib/color_palette_contrast_spec.rb`, which parses the real SCSS variables and checks contrast ratios programmatically, so a future color change that regresses AA fails CI instead of shipping quietly.

## Verification

- `bundle exec rspec` — 911 examples, 0 failures (full suite, feature specs included)
- `bundle exec rubocop` — 407 files, no offenses
- `bundle exec brakeman` — 0 warnings
- `yarn build` — SCSS compiles cleanly

Touches: app/assets/javascripts (SCSS), spec/lib