### PR TITLE
Species page: lead with the plant, not a thumbnail

### DIFF
--- a/app/assets/javascripts/explore/Species.js
+++ b/app/assets/javascripts/explore/Species.js
@@ -1,7 +1,6 @@
 
 import { map, capitalize, isNil } from 'lodash';
 import React, { useContext } from 'react'
-import ReactIntense from 'react-intense'
 import FieldCalendar from './fields/FieldCalendar';
 import ReactMarkdown from 'react-markdown'
 import FieldLight from './fields/FieldLight';
@@ -205,7 +204,7 @@ const Species = ({ species }) => {
             </h4>
             <div className="columns is-multiline">
               {images.map(i => <div key={i.id} className="column is-2">
-                <FieldImage image={i} />
+                <FieldImage image={i} title={capitalize(itype)} />
               </div>)}
             </div>
           </div>)

--- a/app/assets/javascripts/explore/SpeciesPage.jsx
+++ b/app/assets/javascripts/explore/SpeciesPage.jsx
@@ -6,6 +6,7 @@ import Species from './Species';
 import { useEffect } from 'react';
 import CorrectionContext from './CorrectionContext';
 import Review from './Review';
+import SpeciesSkeleton from './elements/SpeciesSkeleton';
 
 const SpeciesPage = ({ slug }) => {
   const [submission, setSubmission] = useState({})
@@ -110,9 +111,7 @@ const SpeciesPage = ({ slug }) => {
       </CorrectionContext.Provider>
     </>
   } else {
-    return (<div>
-      <h2>Loading...</h2>
-    </div>)
+    return <SpeciesSkeleton />
   }
 }
 

--- a/app/assets/javascripts/explore/elements/SpeciesSkeleton.js
+++ b/app/assets/javascripts/explore/elements/SpeciesSkeleton.js
@@ -1,0 +1,21 @@
+import React from 'react'
+
+// Shown by SpeciesPage while the species payload (specifications, growth,
+// images, distribution, synonyms) is still loading, so the content column
+// doesn't collapse to a bare "Loading..." string on an otherwise empty page
+// (see issue #239).
+const SpeciesSkeleton = () => (
+  <div className="species-skeleton" aria-busy="true" aria-live="polite">
+    <span className="is-sr-only">Loading species data…</span>
+    {[0, 1, 2].map(section => (
+      <section className="section content" key={section}>
+        <div className="skeleton-line skeleton-line--title" />
+        <div className="skeleton-line" />
+        <div className="skeleton-line" />
+        <div className="skeleton-line skeleton-line--short" />
+      </section>
+    ))}
+  </div>
+)
+
+export default SpeciesSkeleton

--- a/app/assets/javascripts/explore/fields/FieldImage.js
+++ b/app/assets/javascripts/explore/fields/FieldImage.js
@@ -7,7 +7,8 @@ import { firstNotNil } from '../utils/utils'
 import ReactIntense from 'react-intense'
 
 const FieldImage = ({
-  image
+  image,
+  title
 }) => {
   // const { edit, correction, setFields } = useContext(CorrectionContext)
   // const realValue = firstNotNil(correction[name], value)
@@ -31,7 +32,7 @@ const FieldImage = ({
   // }
 
   return <span>
-    <ReactIntense src={image.image_url} vertical={false} moveSpeed={0} caption={image.copyright} />
+    <ReactIntense src={image.image_url} vertical={false} moveSpeed={0} title={title} caption={image.copyright} />
   </span>
 }
 

--- a/app/assets/javascripts/sections/_explore.scss
+++ b/app/assets/javascripts/sections/_explore.scss
@@ -189,7 +189,8 @@
 // Real <img>/placeholder rendered by SpeciesPhotoHelper#species_photo_tag, replacing
 // the background-image divs the cards and headers used to rely on (see issue #232).
 .species-grid-item-photo,
-.species-correction-image-photo {
+.species-correction-image-photo,
+.species-lead-photo {
   width: 100%;
   height: 100%;
   object-fit: cover;
@@ -198,7 +199,8 @@
 }
 
 .species-grid-item-photo--empty,
-.species-correction-image-photo--empty {
+.species-correction-image-photo--empty,
+.species-lead-photo--empty {
   width: 100%;
   height: 100%;
   display: flex;
@@ -210,6 +212,49 @@
     color: #3ca35a;
     font-size: 2rem;
   }
+}
+
+// Large lead image on the species page header, replacing the 270px square
+// thumbnail that used to sit next to the title (see issue #239).
+.species-lead-image {
+  height: 100%;
+  min-height: 320px;
+  border-radius: 6px;
+  overflow: hidden;
+  display: flex;
+}
+
+.species-lead-photo--empty i {
+  font-size: 4rem;
+}
+
+// Placeholder shown by SpeciesPage while the React payload is still loading,
+// standing in for the "Loading..." text and roughly matching the final
+// sections layout (see issue #239).
+.species-skeleton {
+  .skeleton-line {
+    height: 1em;
+    margin-bottom: .75em;
+    border-radius: 3px;
+    background: linear-gradient(90deg, #eee 25%, #f5f5f5 37%, #eee 63%);
+    background-size: 400% 100%;
+    animation: skeleton-pulse 1.4s ease infinite;
+
+    &--title {
+      width: 40%;
+      height: 1.75em;
+      margin-bottom: 1.25em;
+    }
+
+    &--short {
+      width: 60%;
+    }
+  }
+}
+
+@keyframes skeleton-pulse {
+  0% { background-position: 100% 50%; }
+  100% { background-position: 0 50%; }
 }
 
 .line {

--- a/app/views/explore/species/_species_header.html.erb
+++ b/app/views/explore/species/_species_header.html.erb
@@ -6,13 +6,13 @@
     </ul>
   </nav>
 
-  <div class="columns">
-    <div class="column is-3">
-      <aside class="species-correction-image">
-        <%= species_photo_tag(species, css_class: 'species-correction-image-photo', width: 300, height: 300) %>
+  <div class="columns species-lead">
+    <div class="column is-5">
+      <aside class="species-lead-image">
+        <%= species_photo_tag(species, css_class: 'species-lead-photo', width: 700, height: 500) %>
       </aside>
     </div>
-    <div class="column is-9">
+    <div class="column is-7">
           <div class="container">
             <h1 class="title is-1 scientific-name">
               <%= species.scientific_name %>
@@ -25,12 +25,6 @@
             </h2>
             <p class="subtitle">
               <%= fa_icon('book', class: 'has-text-success') %> <%= species.author || 'No author' %> <%= species.year || 'No year' %> - <i><%= species.bibliography || 'No bibliography' %></i>
-              <%
-=begin%>
- <br />
-              <%= species.observations %> 
-<%
-=end%>
             </p>
           </div>
     </div>

--- a/spec/features/species_page_spec.rb
+++ b/spec/features/species_page_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.feature 'Species page', type: :feature do
+  scenario 'Species with a photo gets a large lead image instead of a small thumbnail' do
+    species = create(:species, main_image_url: 'https://bs.plantnet.org/image/o/abc123.jpg')
+
+    visit "/explore/species/#{species.slug}"
+
+    expect(page).to have_text(species.scientific_name)
+    photo = page.find('.species-lead-photo', visible: :all)
+    expect(photo[:src]).to eq('https://bs.plantnet.org/image/m/abc123.jpg')
+  end
+
+  scenario 'Species without a photo falls back to the tinted placeholder' do
+    species = create(:species, main_image_url: nil)
+
+    visit "/explore/species/#{species.slug}"
+
+    expect(page).to have_css('.species-lead-photo.species-lead-photo--empty')
+    expect(page).to have_no_css('img.species-lead-photo')
+  end
+end

--- a/spec/requests/web/explore_spec.rb
+++ b/spec/requests/web/explore_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe 'Explore pages', type: :request do
       get explore_species_path(species)
       expect(response.body).not_to include('background-image')
 
-      img = Nokogiri::HTML.fragment(response.body).at_css('.species-correction-image img')
+      img = Nokogiri::HTML.fragment(response.body).at_css('.species-lead-image img')
       expect(img['src']).to eq('https://bs.plantnet.org/image/m/abc123.jpg')
       expect(img['loading']).to eq('lazy')
       expect(img['alt']).to be_present


### PR DESCRIPTION
Closes #239

## What changed

- **Header**: replaced the 270px square thumbnail next to the title with a large lead image (`species_photo_tag` at 700x500, beside the title block). Species without a photo fall back to the existing tinted placeholder from #232 — no new fallback logic needed, the helper already handles it.
- **Loading state**: swapped the bare "Loading..." text for `SpeciesSkeleton`, a placeholder that mirrors the final sections layout instead of a blank page.
- **Galleries**: `FieldImage` already wires each gallery thumbnail through `react-intense`, and its lightbox CSS (`.ri-*` rules) is already loaded globally via `_explore.scss`/`application.css` — clicking a thumbnail and the copyright caption both already worked. I initially misdiagnosed this as missing CSS and added a redundant import; caught and reverted after a standards review flagged the duplication. What I did add: the gallery category (Leaf/Habit/Flower/Bark/Fruit) is now passed through as the lightbox title, alongside the existing copyright caption, for extra context.

## Testing

- New `spec/features/species_page_spec.rb`: species with/without a photo render the lead image or placeholder correctly.
- Updated `spec/requests/web/explore_spec.rb` for the new `.species-lead-image` wrapper class (was `.species-correction-image`).
- Full RSpec suite: 910 examples, 0 failures.
- RuboCop: 0 offenses. Brakeman: 0 warnings.

Note: the skeleton and lightbox interaction are React/client-side and aren't covered by the (rack_test-driven) feature specs — verified by reading `react-intense`'s source and confirming its styles are already loaded, plus a manual dev-server check of the header/placeholder rendering.

Touches: app/views/explore/species, species panel JS, app/assets/stylesheets (species rules)