### PR TITLE
Pin d3-color to >=3.1.0, closing the britecharts ReDoS advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@webpack-cli/serve": ">= 2.0.1"
   },
   "resolutions": {
+    "d3-color": "^3.1.0",
     "babel-loader/find-cache-dir/make-dir/semver": "^6.3.1",
     "css-loader/semver": "^7.5.2",
     "file-loader/loader-utils/json5": "^2.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1748,10 +1748,10 @@ d3-collection@1:
   resolved "https://registry.yarnpkg.com/d3-collection/-/d3-collection-1.0.7.tgz#349bd2aa9977db071091c13144d5e4f16b5b310e"
   integrity sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A==
 
-d3-color@1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.4.1.tgz#c52002bf8846ada4424d55d97982fef26eb3bc8a"
-  integrity sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==
+d3-color@1, d3-color@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.1.0.tgz#395b2833dfac71507f12ac2f7af23bf819de24e2"
+  integrity sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==
 
 d3-contour@1:
   version "1.3.2"


### PR DESCRIPTION
Closes #274

## What

Adds a yarn `resolutions` entry pinning `d3-color` to `^3.1.0`, patched for the ReDoS advisory (GHSA-36jr-mh4h-2g58) that `yarn audit --level high` flagged 4x — once for each of britecharts' `d3@5` sub-dependencies that hard-pin `d3-color@1` (d3-brush, d3-interpolate, d3-scale-chromatic, d3-transition).

## Why not a britecharts bump

The issue suggested evaluating a britecharts 3.0.0 major. Checked: no stable 3.0.0 exists on npm — the only `3.0.0-*` release is `3.0.0-alpha-6.1.6`, last published 2022, still tagged `next`. It still depends on `d3-transition ^1.3.2`, which still pulls `d3-color@1` — so it wouldn't have closed this advisory either, and it's otherwise an unmaintained alpha not worth taking on for this.

## Why the resolution override is safe

`d3-color`'s public API surface used by the pinned v1 packages — `color`, `rgb`, `hsl`, `hcl`, `lab`, `cubehelix` — is unchanged between v1 and v3.1.0. Confirmed by diffing all six named exports. The only thing that changed is the module packaging (ESM) and the internal color-string parser (the actual ReDoS source). Webpack's bundler handles the ESM/CJS interop transparently.

## Verification

- `yarn audit --level high`: 0 vulnerabilities (was flagging d3-color x4 before the fix).
- Built and ran the home page; diffed the rendered `#persp-chart-legend` SVG (colors, structure) before/after the change — byte-identical. No new console errors.
- Note: the `#persp-chart` donut itself renders empty in a headless-Chrome check both **before and after** this change — pre-existing, unrelated to this fix (not something #274 asked to fix).
- `bundle exec rspec`: 923 examples, 0 failures.
- `bundle exec rubocop`: no offenses.
- `bundle exec brakeman`: 0 warnings.

Touches: package.json, yarn.lock