### PR TITLE
Add the missing index on species.wiki_score

### DIFF
--- a/db/migrate/20260905053000_add_index_on_species_wiki_score.rb
+++ b/db/migrate/20260905053000_add_index_on_species_wiki_score.rb
@@ -1,0 +1,14 @@
+class AddIndexOnSpeciesWikiScore < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    # Explore::SpeciesController#index sorts the whole table with
+    # `Species.all.order(wiki_score: :desc)` and no WHERE clause — a plain
+    # btree index lets Postgres satisfy that ORDER BY/LIMIT/OFFSET directly
+    # instead of a sequential scan + (disk-spilling, on deep pages) sort.
+    # A plain ascending index (default NULLS LAST) is scanned backwards to
+    # satisfy DESC, which yields NULLS FIRST — Postgres's own default for
+    # `ORDER BY ... DESC` — so no explicit `order:` index option is needed.
+    add_index :species, :wiki_score, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_09_04_100001) do
+ActiveRecord::Schema[8.0].define(version: 2026_09_05_053000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -475,6 +475,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_04_100001) do
     t.index ["scientific_name"], name: "species_scientific_name_index", unique: true
     t.index ["slug"], name: "index_species_on_slug"
     t.index ["token"], name: "index_species_on_token"
+    t.index ["wiki_score"], name: "index_species_on_wiki_score"
   end
 
   create_table "species_distributions", force: :cascade do |t|


### PR DESCRIPTION
Closes #276.

## Problem

None of the 24 indexes on `species` covers `wiki_score`, yet the explore pages sort on it (`Explore::SpeciesController#index`, `Explore::GenusController`, `lib/quality/priorities.rb`). Measured with `EXPLAIN ANALYZE` on the production dataset (489,358 rows):
- page 1: parallel sequential scan + top-N heapsort, 107 ms
- deep page (`OFFSET 100000`): parallel sequential scan + external merge sort spilling 60-85 MB to disk per worker, 537 ms

## Fix

One migration adding a plain btree index on `species.wiki_score` (via `algorithm: :concurrently`, since `species` is a large, actively-queried table):

- `Explore::SpeciesController#index` sorts the whole table (`Species.all.order(wiki_score: :desc)`) with no `WHERE` clause — the dominant, highest-traffic case. A single ascending index (Postgres scans it backward for `DESC`) satisfies that `ORDER BY ... LIMIT/OFFSET` directly.
- The genus-scoped queries (`Explore::GenusController`) already ride the `genus_id` index against small per-genus result sets — no benefit from a composite index there.
- `lib/quality/priorities.rb`'s fallback query sorts by `wiki_score DESC, COALESCE(completion_ratio, 0) ASC`, but the second key is wrapped in `COALESCE`, so a composite index would need an expression form for marginal benefit on a low-traffic, `LIMIT 100` path — not worth the complexity.

## Verification

`EXPLAIN` on both the page-1 and `OFFSET 100000` variants of the explore query now shows `Index Scan Backward using index_species_on_wiki_score` — no sequential scan, no external sort.

Full RSpec suite: 923 examples, 0 failures. RuboCop: 0 offenses.

Touches: db/migrate, db/schema.rb