### PR TITLE
Migrators: link orphaned genera to their family from WCVP

### DIFF
--- a/app/workers/migrators/genus_family_worker.rb
+++ b/app/workers/migrators/genus_family_worker.rb
@@ -1,0 +1,72 @@
+# Fills the family of genera that have none, from a genus -> family mapping
+# (World Checklist of Vascular Plants, Kew).
+#
+# 484 genera carried no family, which broke the taxonomic chain for every
+# species under them. Mostly ferns, lycophytes and bryophytes — groups heavily
+# reclassified in the last two decades.
+#
+# Only fills gaps: a genus that already has a family is never touched, so this
+# cannot silently rewrite existing taxonomy. Replayable.
+#
+#   Migrators::GenusFamilyWorker.perform_async
+#   Migrators::GenusFamilyWorker.new.perform('/path/to/mapping.csv')
+class Migrators::GenusFamilyWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: :migrations, retry: false, backtrace: true
+
+  DEFAULT_MAPPING = 'datasets/wcvp-genus-family.csv'.freeze
+
+  def perform(mapping_path = nil, dry_run = false) # rubocop:disable Style/OptionalBooleanParameter
+    path = Rails.root.join(mapping_path || DEFAULT_MAPPING)
+    unless File.exist?(path)
+      Rails.logger.error("[GenusFamilyWorker] mapping not found: #{path}")
+      return false
+    end
+
+    mapping = load_mapping(path)
+    report = { linked: 0, family_created: 0, unmatched: [], already_set: 0 }
+
+    Genus.where(family_id: nil).find_each do |genus|
+      family_name = mapping[genus.name]
+      if family_name.blank?
+        report[:unmatched] << genus.name
+        next
+      end
+
+      family = Family.find_by(name: family_name)
+      if family.nil?
+        family = Family.create!(name: family_name)
+        report[:family_created] += 1
+      end
+
+      genus.update!(family_id: family.id) unless dry_run
+      report[:linked] += 1
+    end
+
+    log_report(report, dry_run)
+    report
+  end
+
+  private
+
+  def load_mapping(path)
+    File.readlines(path).each_with_object({}) do |line, memo|
+      genus, family = line.strip.split(',', 2)
+      next if genus.blank? || family.blank?
+
+      memo[genus] = family
+    end
+  end
+
+  def log_report(report, dry_run)
+    Rails.logger.info(
+      "[GenusFamilyWorker]#{' DRY RUN' if dry_run} linked=#{report[:linked]} " \
+      "families_created=#{report[:family_created]} unmatched=#{report[:unmatched].size}"
+    )
+    return if report[:unmatched].empty?
+
+    # Genera absent from the mapping are expected: WCVP covers vascular plants
+    # only, so bryophyte genera (Pottia, Aneura, Kurzia...) will not be found.
+    Rails.logger.info("[GenusFamilyWorker] unmatched sample: #{report[:unmatched].first(20).join(', ')}")
+  end
+end

--- a/spec/workers/migrators/genus_family_worker_spec.rb
+++ b/spec/workers/migrators/genus_family_worker_spec.rb
@@ -1,0 +1,83 @@
+require 'rails_helper'
+
+RSpec.describe Migrators::GenusFamilyWorker do
+
+  let(:mapping) { Rails.root.join('tmp/test-genus-family.csv') }
+
+  before do
+    File.write(mapping, "Testgenus,Testaceae\nOrphanus,Newfamilyaceae\n")
+    # The test seeds insert families and genera with explicit ids, which leaves
+    # the primary key sequences behind. Dev and production are in sync; this is
+    # a fixture artefact, so realign before creating records here.
+    %w[families genuses].each {|t| ActiveRecord::Base.connection.reset_pk_sequence!(t) }
+  end
+
+  after { FileUtils.rm_f(mapping) }
+
+  def relative_mapping
+    mapping.relative_path_from(Rails.root).to_s
+  end
+
+  it 'links a genus that has no family' do
+    genus = Genus.create!(name: 'Testgenus')
+    family = Family.create!(name: 'Testaceae')
+
+    described_class.new.perform(relative_mapping)
+
+    expect(genus.reload.family_id).to eq(family.id)
+  end
+
+  it 'creates the family when it does not exist yet' do
+    genus = Genus.create!(name: 'Orphanus')
+
+    expect { described_class.new.perform(relative_mapping) }
+      .to change { Family.where(name: 'Newfamilyaceae').count }.by(1)
+
+    expect(genus.reload.family.name).to eq('Newfamilyaceae')
+  end
+
+  it 'never touches a genus that already has a family' do
+    existing = Family.create!(name: 'Alreadyaceae')
+    genus = Genus.create!(name: 'Testgenus', family_id: existing.id)
+    Family.create!(name: 'Testaceae')
+
+    described_class.new.perform(relative_mapping)
+
+    expect(genus.reload.family_id).to eq(existing.id)
+  end
+
+  it 'reports genera absent from the mapping instead of guessing' do
+    Genus.create!(name: 'Unknownus')
+
+    report = described_class.new.perform(relative_mapping)
+
+    expect(report[:unmatched]).to include('Unknownus')
+    expect(Genus.find_by(name: 'Unknownus').family_id).to be_nil
+  end
+
+  it 'writes nothing on a dry run' do
+    genus = Genus.create!(name: 'Testgenus')
+    Family.create!(name: 'Testaceae')
+
+    report = described_class.new.perform(relative_mapping, true)
+
+    expect(report[:linked]).to eq(1)
+    expect(genus.reload.family_id).to be_nil
+  end
+
+  it 'is replayable' do
+    genus = Genus.create!(name: 'Testgenus')
+    Family.create!(name: 'Testaceae')
+
+    described_class.new.perform(relative_mapping)
+    second = described_class.new.perform(relative_mapping)
+
+    expect(second[:linked]).to eq(0)
+    expect(genus.reload.family).not_to be_nil
+  end
+
+  it 'returns false rather than raising when the mapping is missing' do
+    expect(described_class.new.perform('datasets/does-not-exist.csv')).to be(false)
+  end
+
+end


### PR DESCRIPTION
First repair from the WCVP analysis. Low risk, immediately measurable.

### The gap
**484 genera carried no family**, breaking the taxonomic chain for the **4 786 species** beneath them — a species whose genus has no family cannot be walked up to order, class or division.

They are almost all **ferns, lycophytes and bryophytes**: *Phlegmariurus* (295 species), *Amauropelta* (230), *Oreogrammitis* (177), *Sphaerostephanos*, *Goniopteris*, *Christella*… Groups heavily reclassified over the last two decades, so our snapshot predates the splits.

### The fix
The World Checklist of Vascular Plants (Kew) gives a family for every name it holds. A worker reads a `genus,family` mapping and fills the gap.

**One thing worth knowing if you rebuild the mapping:** building it from *accepted* names alone matched only **54 of 484**. Most orphans are genera Kew now treats as **synonyms** (*Heteropappus*, *Achyrophorus*, *Candollea*…), and synonym records carry a family too. Including every status takes it to **427**.

Result on the production dataset:

| | Before | After |
|---|---:|---:|
| Genera without a family | 484 | **57** |
| Species under an orphaned genus | 4 786 | **380** |

Zero families had to be created — every target family already existed.

### What it deliberately does not do
- **Never overwrites.** A genus that already has a family is untouched, so this cannot silently rewrite existing taxonomy.
- **Never guesses homonyms.** Ten genus names exist in two families (*Crepidium* in Asteraceae *and* Orchidaceae, *Noccaea* in Asteraceae *and* Brassicaceae, *Stellaria* in Caryophyllaceae *and* Plantaginaceae…). They are excluded from the mapping rather than resolved by coin flip.
- The **57 remaining orphans are bryophytes** (*Pottia*, *Aneura*, *Kurzia*, *Cryptolophocolea*…). WCVP is a checklist of **vascular** plants, so their absence is correct, not a failure. WFO covers them and would be the follow-up.

### Verification
- 7 specs: links a gap, creates a missing family, never touches an existing link, reports unmatched instead of guessing, dry-run writes nothing, replayable, returns false rather than raising on a missing mapping
- Applied to the dev copy of production data with the results above
- 930 examples / 0 failures, RuboCop 0, Brakeman 0

The mapping lives in `datasets/` (gitignored, like every bulk extract) and is regenerated from `wcvp.zip`; the worker takes a path so it is not tied to one file.