### PR TITLE
Coerce filter values explicitly instead of leaning on ActiveModel's boolean cast

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -14,6 +14,7 @@ module Api
     rescue_from ActionDispatch::Http::Parameters::ParseError, with: :render_malformed_request_response
     rescue_from ActionController::BadRequest, with: :render_bad_request_response
     rescue_from UnknownQueryKeyError, with: :render_unknown_query_key_response
+    rescue_from Filterable::InvalidFilterValueError, with: :render_invalid_filter_value_response
     rescue_from ActiveRecord::RecordInvalid, with: :render_unprocessable_record_response
     rescue_from ActionController::ParameterMissing, with: :render_unprocessable_entity_response
     rescue_from ActiveRecord::RecordNotFound, with: :render_not_found_response
@@ -185,6 +186,10 @@ module Api
     end
 
     def render_unknown_query_key_response(exception)
+      render_error(exception.message, :bad_request)
+    end
+
+    def render_invalid_filter_value_response(exception)
       render_error(exception.message, :bad_request)
     end
 

--- a/app/models/concerns/filterable.rb
+++ b/app/models/concerns/filterable.rb
@@ -1,11 +1,18 @@
 module Filterable
   extend ActiveSupport::Concern
 
+  # Raised (rendered as 400, same style as ApiController::UnknownQueryKeyError)
+  # when a boolean-column filter is given a token outside the accepted set.
+  class InvalidFilterValueError < StandardError; end
+
+  TRUE_VALUES = %w[true yes 1 on].freeze
+  FALSE_VALUES = %w[false no 0 off].freeze
+
   module ClassMethods
     def filter_with(filtering_params)
       results = where(nil)
       filtering_params.each do |key, value|
-        results = results.public_send("filter_by_#{key}", value.split(',').map {|e| convert_value(e) }.compact) if value.present?
+        results = results.public_send("filter_by_#{key}", value.split(',').map {|e| convert_value(key, e) }.compact) if value.present?
       end
       results
     end
@@ -13,14 +20,17 @@ module Filterable
     def filter_not_with(filtering_params)
       results = where(nil)
       filtering_params.each do |key, value|
-        vs = value.present? ? value.split(',').map {|e| convert_value(e) } : nil
+        vs = value.present? ? value.split(',').map {|e| convert_value(key, e) } : nil
         results = results.public_send("filter_not_by_#{key}", vs)
       end
       results
     end
 
-    def convert_value(value)
-      case value.strip
+    def convert_value(key, value)
+      stripped = value.strip
+      return convert_boolean_value(key, stripped) if boolean_column?(key)
+
+      case stripped
       when 'true'
         true
       when 'false'
@@ -28,8 +38,28 @@ module Filterable
       when 'null'
         nil
       else
-        value.strip
+        stripped
       end
+    end
+
+    private
+
+    def boolean_column?(key)
+      columns_hash[key.to_s]&.type == :boolean
+    end
+
+    # ActiveModel's own boolean cast doesn't list "no" among its FALSE_VALUES,
+    # so `where(edible: "no")` used to silently cast to true and collide with
+    # `filter[edible]=yes` (#277/#56). Accept a fixed, documented token set
+    # instead of leaning on that cast.
+    def convert_boolean_value(key, value)
+      normalized = value.downcase
+      return true if TRUE_VALUES.include?(normalized)
+      return false if FALSE_VALUES.include?(normalized)
+      return nil if normalized == 'null'
+
+      raise InvalidFilterValueError, "Invalid value for #{key}: #{value}. " \
+        "Accepted values are: #{(TRUE_VALUES + FALSE_VALUES).join(', ')}."
     end
   end
 end

--- a/spec/requests/api/v1/filter_validation_spec.rb
+++ b/spec/requests/api/v1/filter_validation_spec.rb
@@ -64,6 +64,44 @@ describe 'Filter/order/range key validation', type: :request do
     end
   end
 
+  describe 'GET /api/v1/species filter[edible] boolean coercion (#277)' do
+    # TestSeeds.seed! (spec/rails_helper.rb) loads a shared botanic dataset once per
+    # suite, so the table already holds other edible/non-edible species. Scope every
+    # query down to these two fixtures by scientific_name instead of asserting on the
+    # bare total. `edible` isn't settable directly -- Species#complete_cache_fields
+    # derives it from `vegetable`/`edible_part` on save (app/models/species.rb:321).
+    let!(:edible_species) { create(:species, vegetable: true) }
+    let!(:non_edible_species) { create(:species, vegetable: false) }
+    let(:fixture_names) { [edible_species.scientific_name, non_edible_species.scientific_name].join(',') }
+
+    %w[true yes 1 on TRUE Yes On].each do |token|
+      it "treats #{token.inspect} as truthy" do
+        body = get_json('/api/v1/species', filter: { edible: token, scientific_name: fixture_names })
+
+        expect(response).to have_http_status(:success)
+        expect(body['data'].map {|s| s['id'] }).to eq([edible_species.id])
+      end
+    end
+
+    %w[false no 0 off FALSE No Off].each do |token|
+      it "treats #{token.inspect} as falsy" do
+        body = get_json('/api/v1/species', filter: { edible: token, scientific_name: fixture_names })
+
+        expect(response).to have_http_status(:success)
+        expect(body['data'].map {|s| s['id'] }).to eq([non_edible_species.id])
+      end
+    end
+
+    it 'rejects a value outside the accepted token set with a 400 naming the field and value' do
+      body = get_json('/api/v1/species', filter: { edible: 'banana' })
+
+      expect(response).to have_http_status(:bad_request)
+      expect(body['error']).to eq(true)
+      expect(body['message']).to include('edible')
+      expect(body['message']).to include('banana')
+    end
+  end
+
   describe 'GET /api/v1/plants' do
     it 'rejects an unknown filter_not key with a 400 naming the key' do
       body = get_json('/api/v1/plants', filter_not: { spread: 'null' })


### PR DESCRIPTION
Closes #277.

## Problem
`filter[edible]=yes` and `filter[edible]=no` both returned the same 235-species edible-only set. `Filterable#convert_value` only special-cased the literal strings `true`/`false`/`null`; anything else was passed through raw, and ActiveModel's boolean cast treats `"no"` as truthy because it's not in its `FALSE_VALUES` list.

## Fix
- `Filterable#convert_value` now takes the filter key and, when the target column is boolean (via `columns_hash`), coerces against an explicit token set: `true/false`, `yes/no`, `1/0`, `on/off`, case-insensitive. Anything else on a boolean column raises `Filterable::InvalidFilterValueError`.
- That error is rescued in `Api::ApiController` and rendered as a 400 in the same envelope/style as the existing unknown-key error.
- Because the fix lives in the shared `Filterable` concern and uses generic column-type introspection (not the `Species`-only `COLUMN_TYPES` constant), it also fixes the same latent bug on `Plant#vegetable` for free.

## Tests
- New request specs in `spec/requests/api/v1/filter_validation_spec.rb`: one per accepted token (both cases) verifying the correct species is returned, plus a rejected-value case asserting the 400 envelope names both the field and the bad value.
- Full suite green: `bundle exec rspec` (938 examples, 0 failures), `bundle exec rubocop` (0 offenses), `bundle exec brakeman` (0 warnings).

Touches: app/models/concerns/filterable.rb, app/controllers/api/api_controller.rb, spec/requests