### PR TITLE
Group images with no identified part under an explicit unknown key

### DIFF
--- a/app/serializers/species_serializer.rb
+++ b/app/serializers/species_serializer.rb
@@ -194,7 +194,7 @@ class SpeciesSerializer < BaseSerializer
   # end
 
   def images
-    object.species_images.group_by(&:part).transform_values do |images|
+    object.species_images.group_by {|image| image.part || 'unknown' }.transform_values do |images|
       Panko::ArraySerializer.new(images, each_serializer: SpeciesImageSerializer).to_a
     end
   end

--- a/lib/schemas/v1/species.rb
+++ b/lib/schemas/v1/species.rb
@@ -44,7 +44,8 @@ module Schemas
           habit: image_schema(extras: { description: 'Image(s) of the species habit' }),
           fruit: image_schema(extras: { description: 'Image(s) of the species fruit' }),
           bark: image_schema(extras: { description: 'Image(s) of the species bark' }),
-          other: image_schema(extras: { description: 'Image(s) of the species other ' })
+          other: image_schema(extras: { description: 'Image(s) of the species other ' }),
+          unknown: image_schema(extras: { description: 'Image(s) with no identified part' })
         })
       end
 

--- a/spec/factories/species_images.rb
+++ b/spec/factories/species_images.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :species_image do
+    species_id { Species.first&.id || create(:species).id }
+    image_url { "https://example.com/#{SecureRandom.hex(4)}.jpg" }
+    part { 'flower' }
+  end
+end

--- a/spec/requests/api/v1/species_images_spec.rb
+++ b/spec/requests/api/v1/species_images_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe 'GET /api/v1/species/:id — images with no identified part', type: :request do
+  let(:user) { create(:user) }
+  let(:species) { create(:species) }
+
+  before do
+    create(:species_image, species_id: species.id, part: 'flower')
+    create(:species_image, species_id: species.id, part: nil)
+  end
+
+  it 'groups images with no part under an explicit "unknown" key, never an empty string' do
+    get "/api/v1/species/#{species.id}", params: { token: user.token }
+    body = JSON.parse(response.body)
+
+    images = body.dig('data', 'images')
+
+    expect(response).to have_http_status(:success)
+    expect(images).to have_key('unknown')
+    expect(images['unknown'].size).to eq(1)
+    expect(images).not_to have_key('')
+  end
+end


### PR DESCRIPTION
Closes #278.

`SpeciesSerializer#images` grouped `SpeciesImage` records with `group_by(&:part)`. `part` is a nullable enum with no case for `nil`, so rows with no part landed under a `nil` group key — which Panko/JSON serializes as an empty-string key (reproduced against production: `GET /api/v1/species/236068`, Cocos nucifera).

## Fix

- Group nil-part images under an explicit `'unknown'` key instead of the raw nil key.
- Add `unknown` to the documented `images` schema in `lib/schemas/v1/species.rb`.
- Request spec: creates a species with one `flower`-part image and one nil-part image, asserts the payload has an `unknown` key with the nil-part image and no `""` key. Verified it fails against the old code (empty-string key) and passes with the fix.

Touches: app/serializers/species_serializer.rb, lib/schemas/v1/species.rb, spec/requests, spec/factories

Full RSpec suite green (924 examples), RuboCop clean.