### PR TITLE
Exclude gitignored data-pipeline dirs from local RuboCop scan

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,10 @@ AllCops:
     - 'db/schema.rb'
     - 'db/seeds/**/*.rb'
     - 'db/*'
+    - 'datasets/**/*'
+    - 'records/**/*'
+    - 'lib/crawlers/**/*'
+    - 'app/workers/crawlers/**/*'
 
 Style/HashEachMethods:
   Enabled: true


### PR DESCRIPTION
### Why
`datasets/`, `records/`, `lib/crawlers/`, and `app/workers/crawlers/` are gitignored and untracked, so CI's RuboCop run (which only lints tracked files) never sees them. A bare local `bundle exec rubocop`, though, walks the filesystem regardless of git tracking — a stray file left in one of those directories (e.g. an old dataset dump) can fail a local run for no reason tied to any tracked change. Hit this locally: a 2020-era file under `datasets/old/` had one long line and blocked `bundle exec rubocop` even with a clean `git status`.

### Fix
Add the same four paths already in `.gitignore` to `AllCops: Exclude` in `.rubocop.yml`, mirroring how `vendor/`, `node_modules/`, and `tmp/` are already excluded there.

No dataset/crawler files are touched, moved, or committed — only the tracked lint config changes.

RuboCop clean, full RSpec suite green (923 examples, 0 failures), Brakeman untouched by this change.