### PR TITLE
Arbitrate everything a source can claim, not just counted traits

### DIFF
--- a/config/traits.yml
+++ b/config/traits.yml
@@ -8,9 +8,15 @@
 #
 # Field keys:
 #   category:         core | descriptive | media | morphology | phenology |
-#                     ecology | cultivation | usda_legacy | deprecated | derived
-#                     Only categories listed under completion.counted_categories
-#                     are part of the completion ratio.
+#                     ecology | cultivation | raw | usda_legacy | deprecated |
+#                     derived
+#                     Two separate questions read this. completion.counted_categories
+#                     decides what the completion ratio measures — what we know
+#                     about a plant. arbitration.arbitrated_categories decides
+#                     what source arbitration protects — anything a source can
+#                     claim, which is wider: nomenclature and raw source strings
+#                     are not traits, but they do come from sources and they do
+#                     conflict.
 #   unit:             informative (cm, mm, deg_c, ph, index_0_10...)
 #   plausible_range:  [min, max] — numeric values outside are rejected by the
 #                     ingester and flagged by Checks::PlausibleValues
@@ -24,7 +30,23 @@
 version: 1
 
 completion:
+  # What the completion ratio measures: how much of what we could know about a
+  # plant we actually know. Status and authorship are not knowledge about the
+  # plant, so they are deliberately absent.
   counted_categories: [descriptive, media, morphology, phenology, ecology, cultivation]
+
+arbitration:
+  # What source arbitration protects. Wider than the completion set on purpose:
+  # GBIF and POWO disagreeing on taxon status is exactly the conflict this
+  # system exists to settle, and status is not a trait.
+  arbitrated_categories:
+    [descriptive, media, morphology, phenology, ecology, cultivation, core, raw]
+
+  # Changing a scientific name drives the slug, the plant linkage and the search
+  # tokens. That deserves its own deliberate path, not a silent arbitration
+  # between two crawlers.
+  excluded_fields:
+    - scientific_name
 
 sources:
   # Strongest first. Compared case-insensitively against foreign_sources.slug.
@@ -86,9 +108,11 @@ fields:
   bibliography: { category: core }
   rank: { category: core }
   status: { category: core }
+  phylum: { category: core }
 
   # --- Descriptive ---
   common_name: { category: descriptive }
+  family_common_name: { category: descriptive }
   observations: { category: descriptive }
 
   # --- Media ---
@@ -171,6 +195,18 @@ fields:
   caco_3_tolerance: { category: usda_legacy }
   lifespan: { category: usda_legacy }
   maturation_order: { category: usda_legacy }
+
+  # --- Raw source strings: the untranslated value a source published, kept
+  #     beside the parsed column. Arbitrated (two sources overwriting each
+  #     other's raw text loses information) but never counted, since they
+  #     duplicate a field that is already counted. ---
+  inflorescence_raw: { category: raw }
+  sexuality_raw: { category: raw }
+  pollinisation_raw: { category: raw }
+  dissemination_raw: { category: raw }
+  fruit_shape_raw: { category: raw }
+  maturation_order_raw: { category: raw }
+  biological_type_raw: { category: raw }
 
   # --- Deprecated / derived duplicates ---
   propagated_by: { category: deprecated } # marked @TODO DEPRECATED in the model

--- a/lib/ingester/species.rb
+++ b/lib/ingester/species.rb
@@ -64,10 +64,18 @@ module Ingester
       # end
     end
 
+    # When a source sends a name that disagrees with the record it is being
+    # ingested into, its nomenclature cannot be trusted for that record: it is
+    # describing a different taxon. The name is kept and the nomenclature
+    # fields are dropped.
+    #
+    # Only a *disagreement* triggers this. An ingestion targeted by species_id
+    # that simply omits the name is not one — that used to silently wipe
+    # author, bibliography and rank on every such call.
     def override_names!
       return unless @species
-
-      return unless @data[:scientific_name] != @species&.scientific_name
+      return if @data[:scientific_name].blank?
+      return if @data[:scientific_name] == @species.scientific_name
 
       @data[:scientific_name] = @species&.scientific_name
       @data[:genus_name] = @species&.genus_name
@@ -255,7 +263,7 @@ module Ingester
       source = detected_source
       facts = []
 
-      @species.changes.slice(*Traits.completion_fields).each do |attr, (old_value, new_value)|
+      @species.changes.slice(*Traits.arbitrated_fields).each do |attr, (old_value, new_value)|
         next if new_value.nil?
 
         # Captured before any revert: what the source actually claimed, in a

--- a/lib/traits.rb
+++ b/lib/traits.rb
@@ -11,6 +11,7 @@ module Traits
     def reset!
       @config = nil
       @completion_fields = nil
+      @arbitrated_fields = nil
       @source_priority = nil
       @legacy_value_priority_index = nil
     end
@@ -27,9 +28,28 @@ module Traits
       config.dig('completion', 'counted_categories')
     end
 
-    # Field names participating in the completion ratio
+    # Field names participating in the completion ratio: how much of what we
+    # could know about a plant we actually know.
     def completion_fields
       @completion_fields ||= fields.select {|_, spec| counted_categories.include?(spec['category']) }.keys
+    end
+
+    def arbitrated_categories
+      config.dig('arbitration', 'arbitrated_categories') || counted_categories
+    end
+
+    def arbitration_excluded_fields
+      config.dig('arbitration', 'excluded_fields') || []
+    end
+
+    # Field names source arbitration protects. Deliberately wider than the
+    # completion set: anything a source can claim can be disagreed about, so
+    # nomenclature and raw source strings belong here even though they are not
+    # traits and are not counted.
+    def arbitrated_fields
+      @arbitrated_fields ||= fields
+        .select {|_, spec| arbitrated_categories.include?(spec['category']) }
+        .keys - arbitration_excluded_fields
     end
 
     # A field only counts as "missing" when it makes sense for this species

--- a/spec/lib/ingester_arbitration_spec.rb
+++ b/spec/lib/ingester_arbitration_spec.rb
@@ -209,4 +209,73 @@ RSpec.describe 'Ingester source arbitration' do
     end
   end
 
+  describe 'fields beyond the completion set' do
+    it 'protects taxon status from a weaker source' do
+      ingest({ source_powo: 'p', status: 'accepted' })
+      ingest({ source_gbif: 'g', status: 'doubtful' })
+
+      expect(species.reload.status).to eq('accepted')
+    end
+
+    it 'records the losing nomenclature claim rather than dropping it' do
+      ingest({ source_powo: 'p', status: 'accepted' })
+      ingest({ source_gbif: 'g', status: 'doubtful' })
+
+      values = species.species_facts.active_status.for_attribute('status').pluck(:source, :value)
+      expect(values).to contain_exactly(%w[powo accepted], %w[gbif doubtful])
+    end
+
+    it 'lets a stronger source correct the status whatever the order' do
+      ingest({ source_gbif: 'g', status: 'doubtful' })
+      ingest({ source_powo: 'p', status: 'accepted' })
+
+      expect(species.reload.status).to eq('accepted')
+    end
+
+    it 'protects raw source strings, which used to overwrite silently' do
+      ingest({ source_powo: 'p', sexuality_raw: 'dioecious' })
+      ingest({ source_catminat: 'c', sexuality_raw: 'dioique' })
+
+      expect(species.reload.sexuality_raw).to eq('dioecious')
+      expect(species.species_facts.for_attribute('sexuality_raw').count).to eq(2)
+    end
+
+    it 'arbitrates year and bibliography too' do
+      ingest({ source_powo: 'p', year: 1753, bibliography: 'Sp. Pl.' })
+      ingest({ source_gbif: 'g', year: 1900, bibliography: 'Elsewhere' })
+
+      expect(species.reload.year).to eq(1753)
+      expect(species.bibliography).to eq('Sp. Pl.')
+    end
+
+    it 'no longer wipes nomenclature when the name is simply absent' do
+      # A targeted ingestion that omits scientific_name is not a disagreement,
+      # but it used to clear author, bibliography and rank all the same.
+      ingest({ source_powo: 'p', author: 'L.', bibliography: 'Sp. Pl.' })
+
+      expect(species.reload.author).to eq('L.')
+      expect(species.bibliography).to eq('Sp. Pl.')
+    end
+
+    it 'still drops nomenclature when the source names a different taxon' do
+      species.update!(author: 'L.')
+
+      ingest({ source_powo: 'p', scientific_name: 'Totally different', author: 'Someone else' })
+
+      expect(species.reload.author).to eq('L.')
+      expect(species.scientific_name).not_to eq('Totally different')
+    end
+
+    it 'leaves scientific_name out of arbitration' do
+      # Renaming drives the slug, the plant linkage and the search tokens, so it
+      # must not be settled silently between two crawlers.
+      expect(Traits.arbitrated_fields).not_to include('scientific_name')
+    end
+
+    it 'keeps the completion set narrower than the arbitrated set' do
+      expect(Traits.completion_fields).not_to include('status', 'rank', 'author')
+      expect(Traits.arbitrated_fields).to include('status', 'rank', 'author')
+    end
+  end
+
 end


### PR DESCRIPTION
Prerequisite for routing GBIF, WFO and POWO through the ingester — without it, routing them would protect one field in eight and leave the conflict that actually matters unmanaged.

### The confusion
Two questions had been sharing one list, and they are not the same question:

- **What does the completion ratio measure?** How much of what we could know about a plant we actually know. Status and authorship are not knowledge about the plant, so they are rightly absent.
- **Which fields can a source claim, and therefore disagree about?** Everything it writes — which is wider.

Reusing the completion list for arbitration left nomenclature on last-write-wins. Same two sources, same disagreement, opposite outcomes:

| Field | POWO | GBIF | Result before | Trace |
|---|---|---|---|---|
| `average_height_cm` | 120 | 200 | **120** — POWO wins | 2 facts |
| `status` | accepted | doubtful | **doubtful** — GBIF overwrites | **none** |

GBIF builds its taxonomy by automated consensus; Kew is the authority. The outcome was backwards, and because no fact was recorded, invisible.

### The change
`arbitration.arbitrated_categories` is now declared separately and adds `core` and `raw`: **status, rank, author, year, bibliography, phylum**, plus the seven `*_raw` source strings — which had been overwriting each other silently (Catminat replaced a curated `dioecious` with `dioique`, no trace).

53 counted fields, 66 arbitrated.

**`scientific_name` is explicitly excluded.** Renaming drives the slug, the plant linkage and the search tokens; that deserves a deliberate path, not a silent arbitration between two crawlers.

### A wart the new specs exposed
`override_names!` exists to distrust a source that names a *different* taxon. It fired whenever the name was merely **absent** — so every ingestion targeted by `species_id` silently cleared `author`, `bibliography` and `rank`. Verified on a fresh record: without the name, only `year` survived; with it, all three came through. Now triggers on disagreement only, with a spec each way.

### Verification
- 9 new specs: status protected both orderings, losing claim recorded, raw strings protected, year/bibliography arbitrated, scientific_name excluded, completion set stays narrower, and the two override_names cases
- The demo that exposed the bug replayed: `status` now stays `accepted` and GBIF's `doubtful` is recorded as a conflicting fact
- 948 examples / 0 failures, RuboCop 0, Brakeman 0