### PR TITLE
Ingester: convert phylum, and guard the contract against silent drift

### DIFF
--- a/lib/ingester/converter/text.rb
+++ b/lib/ingester/converter/text.rb
@@ -29,6 +29,8 @@ module Ingester
         planting_description
         planting_sowing_description
 
+        phylum
+
         biological_type_raw
         dissemination_raw
         fruit_shape_raw

--- a/spec/lib/ingester/contract_coverage_spec.rb
+++ b/spec/lib/ingester/contract_coverage_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+# The traits contract and the converters have to agree. A field can be declared
+# arbitrated in config/traits.yml and still be unreachable, because no converter
+# picks its key out of the incoming hash — in which case a source can send it
+# and it is silently dropped. That is how `phylum` went missing: GBIF sends it,
+# the contract expected it, nothing converted it.
+RSpec.describe 'Ingester contract coverage' do
+
+  # Assigned straight from the hash by Ingester::Species#resolve_core_informations!
+  let(:core_direct) { %w[scientific_name rank year author] }
+
+  # Derived by the model from associated records rather than claimed by a
+  # source: common_name comes from the common names, main_image_url from the
+  # images. A source cannot set them directly, and should not.
+  let(:model_derived) { %w[common_name main_image_url] }
+
+  def converter_fields
+    measurement = Ingester::Converter::Measurement::FIELDS.flat_map do |metric|
+      unit = Ingester::Converter::Measurement::DEFAULT_MEASUREMENTS[metric.to_sym]
+      ["#{metric}_#{unit}", "#{metric}_value", "#{metric}_unit"]
+    end
+
+    [
+      Ingester::Converter::Text::FIELDS,
+      Ingester::Converter::Number::FIELDS,
+      Ingester::Converter::Float::FIELDS,
+      Ingester::Converter::Boolean::FIELDS,
+      Ingester::Converter::Enum::FIELDS,
+      Ingester::Converter::Flag::FIELDS
+    ].flatten.map(&:to_s) + measurement
+  end
+
+  it 'can actually ingest every field it claims to arbitrate' do
+    reachable = converter_fields + core_direct + model_derived
+    unreachable = Traits.arbitrated_fields - reachable
+
+    expect(unreachable).to be_empty,
+                           'these fields are arbitrated but no converter reads them, so a ' \
+                           "source sending them would be silently ignored: #{unreachable.join(', ')}"
+  end
+
+  it 'only declares fields that exist as columns' do
+    expect(Traits.fields.keys - Species.column_names).to be_empty
+  end
+
+  it 'ingests phylum, which GBIF sends and nothing used to convert' do
+    species = create(:species)
+
+    Ingester::Species.new({ source_gbif: '1', phylum: 'Tracheophyta' }, species_id: species.id).ingest!
+
+    expect(species.reload.phylum).to eq('Tracheophyta')
+  end
+
+end


### PR DESCRIPTION
Found while routing GBIF: it sends `phylum`, the contract declares it arbitrated, and it never landed. No converter read the key out of the incoming hash, so the value was dropped without an error anywhere.

### The instance
`phylum` added to the text converter. GBIF now fills it.

### The class
Declaring a field in `config/traits.yml` and forgetting to teach a converter about it produces **no failure at all** — the value simply vanishes on its way in. That is a bad failure mode for a contract whose whole point is knowing where values come from.

A spec now asserts every arbitrated field is actually reachable, through one of three routes:
- a converter's `FIELDS` list (including the measurement converter's three key shapes)
- `resolve_core_informations!`, which assigns `scientific_name`, `rank`, `year`, `author` directly
- **model-derived**: `common_name` comes from the common name records, `main_image_url` from the images. Neither is a source's to claim, and the spec says so rather than leaving them looking like oversights.

It fails with the offending field names, so the next person to extend the contract gets told immediately instead of discovering it in production data.

Also pins that the contract only names columns that exist.

### Verification
951 examples / 0 failures, RuboCop 0, Brakeman 0.