### PR TITLE
Ingester: let a source set the common name, and correct a wrong claim

### DIFF
--- a/lib/ingester/converter/common_name.rb
+++ b/lib/ingester/converter/common_name.rb
@@ -17,6 +17,13 @@ module Ingester
                              end
 
         {
+          # The column holds the species' usual English name and is what the
+          # API exposes; the records hold every vernacular name we know. Both
+          # are fed from the same key, the column taking the first name — a
+          # source sending "Okra|Bonnie Green" means the first one is the
+          # common one. Without this the column was unreachable: a source could
+          # send common_name and see it silently dropped.
+          common_name: common_name_arrays.first,
           common_names_attributes: common_name_arrays.map do |i|
             cname = ::CommonName.where(name: i).first
             next nil if cname

--- a/spec/lib/ingester/contract_coverage_spec.rb
+++ b/spec/lib/ingester/contract_coverage_spec.rb
@@ -10,10 +10,14 @@ RSpec.describe 'Ingester contract coverage' do
   # Assigned straight from the hash by Ingester::Species#resolve_core_informations!
   let(:core_direct) { %w[scientific_name rank year author] }
 
-  # Derived by the model from associated records rather than claimed by a
-  # source: common_name comes from the common names, main_image_url from the
-  # images. A source cannot set them directly, and should not.
-  let(:model_derived) { %w[common_name main_image_url] }
+  # Handled by a converter that does not advertise a FIELDS list:
+  # Converter::CommonName reads :common_name, Converter::Image the image keys.
+  let(:converter_without_fields_list) { %w[common_name] }
+
+  # Derived by the model rather than claimed by a source: main_image_url is
+  # picked from the species' images (Species#complete_cache_fields), so a
+  # source neither can nor should set it.
+  let(:model_derived) { %w[main_image_url] }
 
   def converter_fields
     measurement = Ingester::Converter::Measurement::FIELDS.flat_map do |metric|
@@ -32,7 +36,7 @@ RSpec.describe 'Ingester contract coverage' do
   end
 
   it 'can actually ingest every field it claims to arbitrate' do
-    reachable = converter_fields + core_direct + model_derived
+    reachable = converter_fields + core_direct + converter_without_fields_list + model_derived
     unreachable = Traits.arbitrated_fields - reachable
 
     expect(unreachable).to be_empty,

--- a/spec/lib/ingester/converter/common_name_spec.rb
+++ b/spec/lib/ingester/converter/common_name_spec.rb
@@ -26,4 +26,34 @@ RSpec.describe Ingester::Converter::CommonName do
     expect(result).to eq({})
   end
 
+  describe 'the common_name column' do
+    it 'sets the column to the first name given' do
+      result = described_class.resolve!({ common_name: 'Stinging nettle|Ortie' })
+
+      expect(result[:common_name]).to eq('Stinging nettle')
+    end
+
+    it 'reaches the column through the ingester' do
+      species = create(:species)
+
+      Ingester::Species.new({ source_gbif: 'g', common_name: 'Stinging nettle' },
+                            species_id: species.id).ingest!
+
+      # Was silently dropped before: no converter wrote the column, so a source
+      # could send the key and see nothing happen.
+      expect(species.reload.common_name).to eq('Stinging nettle')
+    end
+
+    it 'is arbitrated like any other claimed value' do
+      species = create(:species)
+
+      Ingester::Species.new({ source_powo: 'p', common_name: 'Common nettle' },
+                            species_id: species.id, source: 'powo').ingest!
+      Ingester::Species.new({ source_gbif: 'g', common_name: 'Something else' },
+                            species_id: species.id, source: 'gbif').ingest!
+
+      expect(species.reload.common_name).to eq('Common nettle')
+    end
+  end
+
 end


### PR DESCRIPTION
Found while routing PlantNet, and it corrects something I got wrong in #295.

### The wrong claim
In #295 I excluded `common_name` from the contract coverage guard on the grounds that it was model-derived. **It is not.** `Species#complete_cache_fields` only capitalises a value that is already there — it derives `genus_name`, `family_name` and `family_common_name`, and never touches `common_name`.

So the field was genuinely unreachable, and my exclusion hid exactly the class of bug the guard exists to catch. Verified: GBIF sends the key, the column stayed `nil`.

### The fix
`Converter::CommonName` already read `:common_name` to create the vernacular name records. It now also fills the column, taking the **first** name given — a source sending `Okra|Bonnie Green` means the first one is the common one. The column is the species' usual English name and is what the API exposes; the records hold every name we know.

That also brings it under arbitration, so a POWO common name survives a later GBIF pass.

### The guard, corrected
Two exclusions, now distinguished honestly:
- **`common_name`** — handled by a converter that advertises no `FIELDS` list, which is why the audit missed it in the first place
- **`main_image_url`** — genuinely model-derived, picked from the species' images, so a source neither can nor should set it

### Verification
- 3 new specs: the column takes the first name, it reaches the column through the ingester, and it is arbitrated like any other claimed value
- 954 examples / 0 failures, RuboCop 0, Brakeman 0