### PR TITLE
Facts: record the identifier the value carries at its source

### DIFF
--- a/lib/ingester/species.rb
+++ b/lib/ingester/species.rb
@@ -240,18 +240,27 @@ module Ingester
 
     RESERVED_SOURCE_KEYS = %w[id name type reference url].freeze
 
+    # The source_* keys of the data, as { slug => identifier at that source }.
+    # source_powo: 'urn:lsid:...' means POWO, and that is its id over there.
+    def source_identifiers
+      @source_identifiers ||= @data.keys.map(&:to_s)
+        .filter {|k| k.start_with?('source_') }
+        .to_h {|k| [k.sub(/\Asource_/, '').sub(/_[a-z]{2}\z/, ''), @data[k.to_sym]] }
+        .except(*RESERVED_SOURCE_KEYS)
+    end
+
     # The source of this ingestion: explicit option, else inferred from the
     # source_* keys of the data (strongest one if several), else 'unknown'.
     def detected_source
       return @source if @source.present?
 
-      slugs = @data.keys.map(&:to_s)
-        .filter {|k| k.start_with?('source_') }
-        .map {|k| k.sub(/\Asource_/, '') }
-        .reject {|s| RESERVED_SOURCE_KEYS.include?(s) }
-        .map {|s| s.sub(/_[a-z]{2}\z/, '') } # source_wikipedia_en -> wikipedia
+      source_identifiers.keys.min_by {|s| Traits.priority_index(s) } || 'unknown'
+    end
 
-      slugs.min_by {|s| Traits.priority_index(s) } || 'unknown'
+    # The id this record carries at the source, so a fact can point back at
+    # where its value came from rather than only naming the database.
+    def source_record_id_for(source)
+      source_identifiers[source]&.to_s
     end
 
     # For each changed trait field:
@@ -261,6 +270,7 @@ module Ingester
     # Returns the facts to persist after a successful save.
     def arbitrate_traits!
       source = detected_source
+      source_record_id = source_record_id_for(source)
       facts = []
 
       @species.changes.slice(*Traits.arbitrated_fields).each do |attr, (old_value, new_value)|
@@ -274,6 +284,7 @@ module Ingester
         if rejection
           @species.send("#{attr}=", old_value)
           facts << { attribute_name: attr, source: source, value: claimed,
+                     source_record_id: source_record_id,
                      status: :rejected, notes: rejection }
           next
         end
@@ -283,7 +294,8 @@ module Ingester
           @species.send("#{attr}=", old_value)
         end
 
-        facts << { attribute_name: attr, source: source, value: claimed, status: :active }
+        facts << { attribute_name: attr, source: source, value: claimed,
+                   source_record_id: source_record_id, status: :active }
       end
 
       facts

--- a/spec/lib/ingester_arbitration_spec.rb
+++ b/spec/lib/ingester_arbitration_spec.rb
@@ -278,4 +278,41 @@ RSpec.describe 'Ingester source arbitration' do
     end
   end
 
+  describe 'source identifiers on facts' do
+    it 'records the id the record carries at the source' do
+      ingest({ source_powo: 'urn:lsid:ipni.org:names:857916-1', average_height_value: 120, average_height_unit: 'cm' })
+
+      fact = species.species_facts.find_by(attribute_name: 'average_height_cm')
+      expect(fact.source).to eq('powo')
+      expect(fact.source_record_id).to eq('urn:lsid:ipni.org:names:857916-1')
+    end
+
+    it 'records it on a rejected claim too, so a bad value can be traced back' do
+      ingest({ source_pfaf: 'Some+Plant', average_height_value: 999_999, average_height_unit: 'cm' })
+
+      fact = species.species_facts.find_by(attribute_name: 'average_height_cm')
+      expect(fact.status).to eq('rejected')
+      expect(fact.source_record_id).to eq('Some+Plant')
+    end
+
+    it 'picks the identifier of the source that actually won' do
+      # Two source_* keys in one payload: the strongest names the fact, so its
+      # identifier is the one that has to be recorded.
+      ingest({ source_powo: 'powo-id', source_gbif: 'gbif-id',
+               average_height_value: 120, average_height_unit: 'cm' })
+
+      fact = species.species_facts.find_by(attribute_name: 'average_height_cm')
+      expect(fact.source).to eq('powo')
+      expect(fact.source_record_id).to eq('powo-id')
+    end
+
+    it 'leaves it null when the source was given explicitly' do
+      ingest({ average_height_value: 120, average_height_unit: 'cm' }, source: 'community')
+
+      fact = species.species_facts.find_by(attribute_name: 'average_height_cm')
+      expect(fact.source).to eq('community')
+      expect(fact.source_record_id).to be_nil
+    end
+  end
+
 end


### PR DESCRIPTION
Found while reconciling the WCVP synonymy: a fact said `merged_from_synonym` without saying **which** synonym. The same gap applies to every source.

### The gap
```json
{ "attribute_name": "average_height_cm", "source": "powo", "source_record_id": null }
```

The trail stopped at the database name. Anyone investigating a disagreement had to go and find the taxon by name at the other end — exactly the manual step the facts endpoint exists to remove.

### The payload already carried it
`source_powo: 'urn:lsid:ipni.org:names:857916-1'` names both the source **and** its identifier there. The ingester parsed the key for the slug and discarded the value. It now keeps both.

```json
{ "attribute_name": "average_height_cm", "source": "powo",
  "source_record_id": "urn:lsid:ipni.org:names:857916-1" }
```

### Details worth knowing
- **Rejected claims get it too**, which is where it matters most: a value refused as implausible is precisely one you want to trace back to the record that published it.
- When a payload carries several `source_*` keys, the identifier recorded is the one belonging to the source that **won** the naming — not whichever came first.
- Left null when the source is passed explicitly: an accepted community correction is not a record at some external database, and pretending otherwise would be worse than a blank.

### Verification
- 4 new specs covering each case above
- 958 examples / 0 failures, RuboCop 0, Brakeman 0