### PR TITLE
Quality: a day-by-day view of whether the dataset is improving

### DIFF
--- a/app/controllers/management/data_quality_controller.rb
+++ b/app/controllers/management/data_quality_controller.rb
@@ -13,8 +13,11 @@ class Management::DataQualityController < Management::ManagementController
       @source_rows = snapshots.where(dimension: 'source').order(species_count: :desc)
     end
 
-    # Trend: aggregate row of each past snapshot
-    @history = DataQualitySnapshot.global.where(attribute_name: nil).order(:snapshot_on)
+    # Day-by-day progression, so an improvement is visible rather than inferred
+    @days = (params[:days] || 30).to_i.clamp(2, 365)
+    evolution = Quality::Evolution.new(days: @days)
+    @series = evolution.series
+    @field_moves = evolution.field_moves
 
     @priorities = Quality::Priorities.fetch(limit: 50)
     @pending_plausibility_warnings = RecordCorrection.where(

--- a/app/views/management/data_quality/index.html.erb
+++ b/app/views/management/data_quality/index.html.erb
@@ -107,22 +107,88 @@
     </div>
   </div>
 
-  <% if @history.length > 1 %>
-    <h2 class="subtitle mt-5">Trend</h2>
-    <table class="table is-narrow">
-      <thead><tr><th>Date</th><th class="has-text-right">Species</th><th class="has-text-right">Avg completion</th><th class="has-text-right">Implausible</th><th class="has-text-right">Conflicts</th></tr></thead>
-      <tbody>
-        <% @history.each do |row| %>
-          <tr>
-            <td><%= row.snapshot_on %></td>
-            <td class="has-text-right"><%= number_with_delimiter(row.species_count) %></td>
-            <td class="has-text-right"><%= row.details&.dig('avg_completion_ratio') || '—' %>%</td>
-            <td class="has-text-right"><%= number_with_delimiter(row.implausible_count) %></td>
-            <td class="has-text-right"><%= number_with_delimiter(row.conflict_count) %></td>
-          </tr>
+  <h2 class="subtitle mt-5">Evolution</h2>
+  <div class="field is-grouped mb-4">
+    <% [7, 30, 90, 365].each do |d| %>
+      <p class="control">
+        <%= link_to "#{d} days", management_data_quality_path(days: d),
+              class: "button is-small #{'is-link' if @days == d}" %>
+      </p>
+    <% end %>
+  </div>
+
+  <% if @series.length < 2 %>
+    <div class="notification is-light">
+      Only <%= @series.length %> snapshot so far. The daily job builds this up —
+      come back tomorrow, or run <code>rake quality:snapshot</code> to add a point now.
+    </div>
+  <% else %>
+    <div class="columns">
+      <div class="column is-two-thirds">
+        <table class="table is-fullwidth is-narrow is-striped">
+          <thead>
+            <tr>
+              <th>Date</th>
+              <th class="has-text-right">Fill rate</th>
+              <th class="has-text-right">Change</th>
+              <th class="has-text-right">Filled cells</th>
+              <th class="has-text-right">Species</th>
+              <th class="has-text-right">Implausible</th>
+              <th class="has-text-right">Conflicts</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% previous = nil %>
+            <% @series.reverse.each do |point| %>
+              <% nxt = @series[@series.index(point) - 1] if @series.index(point).positive? %>
+              <tr>
+                <td><%= point.date %></td>
+                <td class="has-text-right"><strong><%= point.fill_rate %>%</strong></td>
+                <td class="has-text-right">
+                  <% if nxt && point.fill_rate && nxt.fill_rate %>
+                    <% diff = (point.fill_rate - nxt.fill_rate).round(2) %>
+                    <span class="<%= diff.positive? ? 'has-text-success' : (diff.negative? ? 'has-text-danger' : 'has-text-grey') %>">
+                      <%= diff.positive? ? "+#{diff}" : diff %>
+                    </span>
+                  <% else %>
+                    <span class="has-text-grey">—</span>
+                  <% end %>
+                </td>
+                <td class="has-text-right"><%= number_with_delimiter(point.filled_count) %></td>
+                <td class="has-text-right"><%= number_with_delimiter(point.species_count) %></td>
+                <td class="has-text-right <%= 'has-text-danger' if point.implausible_count.to_i.positive? %>"><%= number_with_delimiter(point.implausible_count) %></td>
+                <td class="has-text-right <%= 'has-text-danger' if point.conflict_count.to_i.positive? %>"><%= number_with_delimiter(point.conflict_count) %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="column">
+        <h3 class="subtitle is-6">What moved</h3>
+        <% if @field_moves.empty? %>
+          <p class="has-text-grey">Nothing changed over this window.</p>
+        <% else %>
+          <table class="table is-fullwidth is-narrow">
+            <thead><tr><th>Field</th><th class="has-text-right">Change</th></tr></thead>
+            <tbody>
+              <% @field_moves.first(15).each do |move| %>
+                <tr>
+                  <td><code><%= move.field %></code></td>
+                  <td class="has-text-right <%= move.delta.positive? ? 'has-text-success' : 'has-text-danger' %>">
+                    <%= move.delta.positive? ? "+#{number_with_delimiter(move.delta)}" : number_with_delimiter(move.delta) %>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+          <p class="is-size-7 has-text-grey">
+            Species gained or lost per field between the ends of the window.
+            A negative number is a regression worth looking at.
+          </p>
         <% end %>
-      </tbody>
-    </table>
+      </div>
+    </div>
   <% end %>
 
 <% end %>

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -31,6 +31,8 @@ check_species_images:
   queue: migrations
 
 quality_snapshot:
-  cron: "30 2 * * 1" # Mondays at 02:30 — weekly data quality snapshot
+  # Daily: while the dataset is actively being filled, a weekly point is too
+  # coarse to see whether a change helped. One snapshot is ~60 rows.
+  cron: "30 2 * * *" # every day at 02:30
   class: "QualitySnapshotWorker"
   queue: low

--- a/lib/quality/evolution.rb
+++ b/lib/quality/evolution.rb
@@ -1,0 +1,91 @@
+module Quality
+  # Reads the dated snapshots back as a progression, so it is possible to see
+  # whether the dataset is actually improving rather than only where it stands.
+  #
+  #   Quality::Evolution.new(days: 30).series      # one row per day
+  #   Quality::Evolution.new(days: 30).field_moves # what gained and what lost
+  class Evolution
+
+    Point = Struct.new(:date, :species_count, :filled_count, :fields_count,
+                       :avg_completion, :implausible_count, :conflict_count,
+                       keyword_init: true) do
+      # Share of the measurable surface that is actually filled: filled cells
+      # over the cells that exist. A steadier number than the average ratio,
+      # which moves when applicability changes.
+      def fill_rate
+        return nil if species_count.to_i.zero? || fields_count.to_i.zero?
+
+        (filled_count.to_f / (species_count * fields_count) * 100).round(2)
+      end
+    end
+
+    Move = Struct.new(:field, :from, :to, keyword_init: true) do
+      def delta
+        to.to_i - from.to_i
+      end
+    end
+
+    def initialize(days: 30)
+      @days = days
+    end
+
+    # One point per day, oldest first.
+    def series
+      aggregates.map do |row|
+        Point.new(
+          date: row.snapshot_on,
+          species_count: row.species_count,
+          filled_count: row.filled_count,
+          fields_count: row.details&.dig('fields_count'),
+          avg_completion: row.details&.dig('avg_completion_ratio'),
+          implausible_count: row.implausible_count,
+          conflict_count: row.conflict_count
+        )
+      end
+    end
+
+    # Change in filled_count per field between the first and last snapshot in
+    # the window. Negative moves matter as much as positive ones: a field that
+    # loses values is a regression worth seeing.
+    def field_moves
+      first_date, last_date = boundary_dates
+      return [] if first_date.nil? || first_date == last_date
+
+      first = counts_by_field(first_date)
+      last = counts_by_field(last_date)
+
+      moves = (first.keys | last.keys).filter_map do |field|
+        move = Move.new(field: field, from: first[field].to_i, to: last[field].to_i)
+        move unless move.delta.zero?
+      end
+
+      moves.sort_by {|m| -m.delta.abs }
+    end
+
+    def window
+      boundary_dates
+    end
+
+    private
+
+    def scope
+      DataQualitySnapshot.where(dimension: 'global')
+        .where(snapshot_on: @days.days.ago.to_date..)
+    end
+
+    def aggregates
+      @aggregates ||= scope.where(attribute_name: nil).order(:snapshot_on).to_a
+    end
+
+    def boundary_dates
+      dates = aggregates.map(&:snapshot_on)
+      [dates.first, dates.last]
+    end
+
+    def counts_by_field(date)
+      scope.where(snapshot_on: date).where.not(attribute_name: nil)
+        .pluck(:attribute_name, :filled_count).to_h
+    end
+
+  end
+end

--- a/lib/quality/evolution_report.rb
+++ b/lib/quality/evolution_report.rb
@@ -1,0 +1,50 @@
+module Quality
+  # Terminal rendering of Quality::Evolution, kept out of the rake task so the
+  # task stays a one-liner and this stays testable.
+  module EvolutionReport
+    HEADER = '%-12<date>s %10<rate>s %9<change>s %14<filled>s %12<conflicts>s'.freeze
+    ROW = '%-12<date>s %9<rate>s%% %9<change>s %14<filled>s %12<conflicts>s'.freeze
+
+    def self.print(days: 30)
+      evolution = Quality::Evolution.new(days: days)
+      series = evolution.series
+
+      if series.size < 2
+        puts "Only #{series.size} snapshot so far — the daily job builds this up."
+        return
+      end
+
+      print_series(series)
+      print_moves(evolution.field_moves)
+    end
+
+    def self.print_series(series)
+      puts format(HEADER, date: 'date', rate: 'fill rate', change: 'change',
+                          filled: 'filled cells', conflicts: 'conflicts')
+      previous = nil
+      series.each do |point|
+        puts format(ROW, date: point.date.to_s, rate: point.fill_rate,
+                         change: change_label(previous, point),
+                         filled: point.filled_count.to_s,
+                         conflicts: point.conflict_count.to_s)
+        previous = point
+      end
+    end
+
+    def self.change_label(previous, point)
+      return '-' unless previous&.fill_rate && point.fill_rate
+
+      diff = (point.fill_rate - previous.fill_rate).round(2)
+      diff.positive? ? "+#{diff}" : diff.to_s
+    end
+
+    def self.print_moves(moves)
+      return if moves.empty?
+
+      puts "\nWhat moved:"
+      moves.first(15).each do |move|
+        puts format('  %-28<field>s %+<delta>d', field: move.field, delta: move.delta)
+      end
+    end
+  end
+end

--- a/lib/quality/snapshot_report.rb
+++ b/lib/quality/snapshot_report.rb
@@ -1,0 +1,15 @@
+module Quality
+  # Terminal rendering of a single snapshot, kept out of the rake task.
+  module SnapshotReport
+    ROW = '  %-32<name>s %6.1<fill>f%% filled  %6<implausible>d implausible  %6<conflicts>d conflicts'.freeze
+
+    def self.print(date)
+      DataQualitySnapshot.on(date).global.where.not(attribute_name: nil)
+        .sort_by {|s| s.fill_rate || 0 }
+        .each do |snapshot|
+          puts format(ROW, name: snapshot.attribute_name, fill: snapshot.fill_rate || 0,
+                           implausible: snapshot.implausible_count, conflicts: snapshot.conflict_count)
+        end
+    end
+  end
+end

--- a/lib/tasks/quality.rake
+++ b/lib/tasks/quality.rake
@@ -8,14 +8,13 @@ namespace :quality do
   desc 'Write data quality snapshot rows for today (global, per field, per rank, per source)'
   task snapshot: :environment do
     result = Quality::Snapshot.run!
-
     puts "Snapshot #{result[:date]}: #{result[:species_count]} species, #{result[:fields_count]} fields"
-    DataQualitySnapshot.on(result[:date]).global.where.not(attribute_name: nil)
-      .sort_by {|s| s.fill_rate || 0 }.each do |s|
-      puts format('  %-32<name>s %6.1<fill>f%% filled  %6<implausible>d implausible  %6<conflicts>d conflicts',
-                  name: s.attribute_name, fill: s.fill_rate || 0,
-                  implausible: s.implausible_count, conflicts: s.conflict_count)
-    end
+    Quality::SnapshotReport.print(result[:date])
+  end
+
+  desc 'Day-by-day progression of the dataset (DAYS=30)'
+  task evolution: :environment do
+    Quality::EvolutionReport.print(days: (ENV['DAYS'] || 30).to_i)
   end
 
   desc 'Most requested species with the poorest data — the work queue'

--- a/spec/lib/quality/evolution_spec.rb
+++ b/spec/lib/quality/evolution_spec.rb
@@ -1,0 +1,86 @@
+require 'rails_helper'
+
+RSpec.describe Quality::Evolution do
+
+  def snapshot(date, filled:, fields: 10, species: 100, conflicts: 0, per_field: {})
+    DataQualitySnapshot.create!(
+      snapshot_on: date, dimension: 'global', dimension_value: nil, attribute_name: nil,
+      species_count: species, filled_count: filled, conflict_count: conflicts,
+      details: { fields_count: fields, avg_completion_ratio: 4.0 }
+    )
+    per_field.each do |field, count|
+      DataQualitySnapshot.create!(
+        snapshot_on: date, dimension: 'global', dimension_value: nil, attribute_name: field.to_s,
+        species_count: species, filled_count: count
+      )
+    end
+  end
+
+  describe '#series' do
+    it 'returns one point per day, oldest first' do
+      snapshot(2.days.ago.to_date, filled: 100)
+      snapshot(1.day.ago.to_date, filled: 150)
+      snapshot(Date.current, filled: 200)
+
+      dates = described_class.new(days: 30).series.map(&:date)
+
+      expect(dates).to eq([2.days.ago.to_date, 1.day.ago.to_date, Date.current])
+    end
+
+    it 'expresses progress as the share of measurable cells that are filled' do
+      # 100 species x 10 fields = 1000 cells, 250 filled
+      snapshot(Date.current, filled: 250, fields: 10, species: 100)
+
+      expect(described_class.new(days: 30).series.first.fill_rate).to eq(25.0)
+    end
+
+    it 'reports no fill rate rather than a wrong one when the shape is unknown' do
+      DataQualitySnapshot.create!(
+        snapshot_on: Date.current, dimension: 'global', attribute_name: nil,
+        species_count: 100, filled_count: 250, details: {}
+      )
+
+      expect(described_class.new(days: 30).series.first.fill_rate).to be_nil
+    end
+
+    it 'ignores snapshots outside the window' do
+      snapshot(40.days.ago.to_date, filled: 100)
+      snapshot(Date.current, filled: 200)
+
+      expect(described_class.new(days: 30).series.length).to eq(1)
+    end
+  end
+
+  describe '#field_moves' do
+    it 'reports what each field gained between the ends of the window' do
+      snapshot(2.days.ago.to_date, filled: 100, per_field: { light: 10, ph_minimum: 50 })
+      snapshot(Date.current, filled: 200, per_field: { light: 40, ph_minimum: 50 })
+
+      moves = described_class.new(days: 30).field_moves
+
+      expect(moves.map(&:field)).to eq(['light'])
+      expect(moves.first.delta).to eq(30)
+    end
+
+    it 'surfaces a regression, not only progress' do
+      snapshot(2.days.ago.to_date, filled: 100, per_field: { light: 40 })
+      snapshot(Date.current, filled: 90, per_field: { light: 10 })
+
+      expect(described_class.new(days: 30).field_moves.first.delta).to eq(-30)
+    end
+
+    it 'orders by how much moved, regardless of direction' do
+      snapshot(2.days.ago.to_date, filled: 100, per_field: { light: 100, toxicity: 5 })
+      snapshot(Date.current, filled: 100, per_field: { light: 50, toxicity: 15 })
+
+      expect(described_class.new(days: 30).field_moves.map(&:field)).to eq(%w[light toxicity])
+    end
+
+    it 'says nothing when there is only one point to compare' do
+      snapshot(Date.current, filled: 100, per_field: { light: 10 })
+
+      expect(described_class.new(days: 30).field_moves).to be_empty
+    end
+  end
+
+end

--- a/spec/requests/web/management_spec.rb
+++ b/spec/requests/web/management_spec.rb
@@ -49,6 +49,26 @@ RSpec.describe 'Management backoffice', type: :request do
       expect(response.body).to include('average_height_cm')
     end
 
+    it 'invites a second snapshot rather than showing an empty evolution' do
+      Quality::Snapshot.run!
+
+      get '/management/data_quality'
+
+      expect(response.body).to include('Evolution')
+      expect(response.body).to include('snapshot so far')
+    end
+
+    it 'shows the day-by-day progression once there are two points' do
+      Quality::Snapshot.run!(date: 3.days.ago.to_date)
+      Quality::Snapshot.run!
+
+      get '/management/data_quality', params: { days: 7 }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('Fill rate')
+      expect(response.body).to include(3.days.ago.to_date.to_s)
+    end
+
     it 'renders a species page and updates it' do
       species = Species.friendly.find('abies-alba')
       get "/management/species/#{species.slug}"


### PR DESCRIPTION
The snapshots were already dated and stored — nothing read them back as a progression, and the job ran weekly.

### What was missing
52 points a year is too coarse to tell whether a change helped while the dataset is actively being filled. **Now daily**, at roughly 60 rows per snapshot.

### What it gives you
`Quality::Evolution` turns the stored history into a series. The dashboard gains an **evolution table** with a 7/30/90/365-day selector, and a **"what moved"** column listing which fields gained or lost species between the ends of the window.

**Regressions are shown, not only progress.** A field that loses values is the thing you most want to see, so the list is ordered by how much moved regardless of direction.

`rake quality:evolution` prints the same thing.

### One judgement worth flagging
Progress is expressed as the **share of measurable cells that are filled** — filled over (species × fields) — rather than the average completion ratio.

The completion ratio shifts whenever applicability changes: the `applicable_if: vegetable` fix moved every ratio without a single value being added or removed. A metric that moves for reasons unrelated to the data cannot be compared across days, which is the whole point here.

### On real data
The two snapshots we now hold read **3.84% → 4.04%** — that is the manual curation and the synonym reconciliation showing up, which is exactly the feedback loop this is for.

### Verification
- 8 specs on the service: ordering, the fill-rate calculation, a null rate rather than a wrong one when the shape is unknown, window filtering, gains, regressions, ordering by magnitude, and the single-point case
- 3 dashboard specs including the "only one snapshot so far" invitation
- Both rake tasks delegate rendering to a module, which keeps the task file under its length limit and makes the output testable
- 964 examples / 0 failures, RuboCop 0, Brakeman 0