### PR TITLE
Replace the heater with a cache warmer inside the app

### DIFF
--- a/app/workers/cache_warmer_worker.rb
+++ b/app/workers/cache_warmer_worker.rb
@@ -1,0 +1,89 @@
+# Keeps the serialization cache warm for the records people actually request.
+#
+# Replaces the standalone "heater" service, which walked every collection in an
+# infinite loop with a half-second pause. At 489k species that is 68 days for a
+# single pass, so it never completed one — and it needed its own image, its own
+# deployment and an unlimited API token baked into the manifest.
+#
+# This runs in the app instead. Two consequences worth stating:
+#
+#   * Requests are issued in-process through the Rack stack, so they go through
+#     the real controllers and populate exactly the cache keys a real request
+#     would look up. Reproducing those keys by hand would drift the first time
+#     a controller changed what it caches.
+#   * Work is ordered by demand rather than by table order, so the budget goes
+#     to records that are actually looked up.
+class CacheWarmerWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :low, retry: false, backtrace: true
+
+  DEFAULT_BATCH = 200
+  COLLECTIONS = %w[
+    /api/v1/kingdoms
+    /api/v1/subkingdoms
+    /api/v1/families
+    /api/v1/distributions
+    /api/v1/genus
+    /api/v1/plants
+    /api/v1/species
+  ].freeze
+
+  def perform(batch_size = DEFAULT_BATCH)
+    token = warming_token
+    unless token
+      Rails.logger.error('[CacheWarmer] no unlimited token available, skipping')
+      return false
+    end
+
+    warmed = 0
+    warmed += warm_collections(token)
+    warmed += warm_records(token, batch_size)
+
+    Rails.logger.info("[CacheWarmer] warmed #{warmed} responses")
+    warmed
+  end
+
+  private
+
+  # rack-attack safelists tokens starting with 'unl-', so warming does not eat
+  # into anyone's quota and cannot throttle itself. Read from the database
+  # rather than the environment: the old service carried its token in a
+  # committed manifest, which is how it ended up needing rotation.
+  def warming_token
+    User.where(admin: true).find_each do |user|
+      return user.token if user.token&.starts_with?('unl-')
+    end
+    nil
+  end
+
+  def warm_collections(token)
+    COLLECTIONS.count {|path| get(path, token) }
+  end
+
+  # Most-requested first. species_trends is the real signal; gbif_score stands
+  # in until it is populated, the same fallback the work queue uses.
+  def warm_records(token, batch_size)
+    species = Species.order(gbif_score: :desc).limit(batch_size).pluck(:slug)
+    plants = Plant.order(main_species_gbif_score: :desc).limit(batch_size / 2).pluck(:slug)
+
+    species.count {|slug| get("/api/v1/species/#{slug}", token) } +
+      plants.count {|slug| get("/api/v1/plants/#{slug}", token) }
+  end
+
+  def get(path, token)
+    env = Rack::MockRequest.env_for(
+      "http://localhost#{path}?token=#{token}",
+      'HTTP_HOST' => 'localhost'
+    )
+    status, = Rails.application.call(env)
+    return true if status == 200
+
+    Rails.logger.warn("[CacheWarmer] #{path} returned #{status}")
+    false
+  rescue StandardError => e
+    # One bad record must not stop the sweep.
+    Rails.logger.warn("[CacheWarmer] #{path} raised #{e.class}: #{e.message}")
+    false
+  end
+end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -30,6 +30,14 @@ check_species_images:
   class: "Migrators::ImagesFixerWorker"
   queue: migrations
 
+cache_warmer:
+  # Replaces the standalone heater service. Keeps the serialization cache warm
+  # for the most-requested records; a run is bounded, so this is a steady trickle
+  # rather than the old infinite loop.
+  cron: "*/20 * * * *" # every 20 minutes
+  class: "CacheWarmerWorker"
+  queue: low
+
 quality_snapshot:
   # Daily: while the dataset is actively being filled, a weekly point is too
   # coarse to see whether a change helped. One snapshot is ~60 rows.

--- a/spec/workers/cache_warmer_worker_spec.rb
+++ b/spec/workers/cache_warmer_worker_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe CacheWarmerWorker do
+
+  let(:admin) { create(:admin) }
+
+  before { admin.update_columns(token: "unl-#{SecureRandom.hex(8)}") }
+
+  it 'warms the collections and the most-requested records' do
+    expect(described_class.new.perform(2)).to be_positive
+  end
+
+  # The test environment uses a NullStore, which includes LocalCache — so a
+  # request through the Rack stack leaves a request-local cache behind and
+  # `exist?` answers true for keys nothing durably stored. Asserting against
+  # that would pass whether or not warming works, so this example swaps in a
+  # store that really keeps what it is given.
+  it 'populates the cache a real request would read' do
+    store = ActiveSupport::Cache::MemoryStore.new
+    allow(Rails).to receive(:cache).and_return(store)
+
+    species = Species.order(gbif_score: :desc).first
+    key = "SpeciesSerializer/#{species.cache_key}-#{species.cache_version}"
+    expect(store.exist?(key)).to be(false)
+
+    described_class.new.perform(1)
+
+    # Going through the Rack stack rather than reproducing the key by hand is
+    # the point: what gets warmed is what a request looks up.
+    expect(store.exist?(key)).to be(true)
+  end
+
+  it 'declines to run without an unlimited token rather than burning quota' do
+    admin.update_columns(token: 'spo-limited')
+
+    expect(described_class.new.perform(1)).to be(false)
+  end
+
+  it 'keeps going when one record fails' do
+    allow(Rails.application).to receive(:call).and_raise(StandardError, 'boom')
+
+    expect { described_class.new.perform(1) }.not_to raise_error
+  end
+
+  it 'warms nothing but does not fail when a batch size of zero is asked for' do
+    expect(described_class.new.perform(0)).to be >= 0
+  end
+
+end


### PR DESCRIPTION
The standalone heater was removed from the cluster last week. This is its replacement, and it is a different design rather than a port.

### What was wrong with the old one
- It walked every collection in an infinite loop with a half-second pause. **At 489k species that is 68 days for a single pass** — it never completed one, and warmed in table order, so the records people actually request got no priority.
- It needed its own repository, image and deployment for about sixty lines of script.
- It carried an **unlimited API token in a committed manifest** — the one still waiting to be rotated.

### The replacement
A scheduled worker in the app, every 20 minutes, bounded per run. Two decisions worth stating:

**Requests go through the Rack stack in-process** rather than reproducing cache keys by hand. The controller caches a `Panko::Response` built from a serializer, links and per-endpoint meta; rebuilding that outside the controller would drift the first time an endpoint changed what it caches. Going through the real path means what gets warmed is what a request looks up, by construction.

**Order follows demand**, so a bounded budget goes to records that are looked up rather than to whatever comes first in the table. The token is read from an admin account at run time — rack-attack safelists `unl-` tokens, so warming neither eats a quota nor throttles itself — instead of living in a manifest.

### The spec needed care
The test environment's `NullStore` includes `LocalCache`, so a request through the Rack stack leaves a **request-local** cache behind and `exist?` answers true for keys nothing durably stored. My first version of the assertion passed whether or not warming worked.

It now swaps in a store that really keeps what it is given. Verified by deleting the warming call: the spec fails. Verified against a real store on the production dataset: 8 responses warmed, the key absent before and present after.

### Verification
- 5 specs: warms something, populates the cache a request would read, declines to run without an unlimited token rather than burning quota, survives one record failing, handles a zero batch
- 973 examples / 0 failures, RuboCop 0, Brakeman 0

Once this is deployed, `trefle-heater/` can be deleted from the workspace and its token revoked.