### PR TITLE
Resolve merged species through their synonym slug

### DIFF
--- a/app/controllers/api/v1/plants_controller.rb
+++ b/app/controllers/api/v1/plants_controller.rb
@@ -43,7 +43,7 @@ class Api::V1::PlantsController < Api::ApiController
   end
 
   def show
-    @resource = Species.friendly.find(params[:id])
+    @resource = Species.friendly_or_synonym!(params[:id])
 
     render_serialized_resource(
       @resource.plant,

--- a/app/controllers/api/v1/species_controller.rb
+++ b/app/controllers/api/v1/species_controller.rb
@@ -182,7 +182,7 @@ class Api::V1::SpeciesController < Api::ApiController
   end
 
   def show
-    @resource = Species.friendly.find(params[:id])
+    @resource = Species.friendly_or_synonym!(params[:id])
 
     render_serialized_resource(
       @resource,
@@ -198,7 +198,7 @@ class Api::V1::SpeciesController < Api::ApiController
   # Provenance of the species trait values: one row per (attribute, source)
   # claim, including superseded and rejected ones (transparency)
   def facts
-    @resource = Species.friendly.find(params[:id])
+    @resource = Species.friendly_or_synonym!(params[:id])
     facts = @resource.species_facts.order(:attribute_name, :source, :id)
 
     render json: Panko::Response.new(

--- a/app/controllers/explore/species_controller.rb
+++ b/app/controllers/explore/species_controller.rb
@@ -110,7 +110,7 @@ class Explore::SpeciesController < Explore::ExploreController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_species
-    @species = Species.friendly.find(params[:id])
+    @species = Species.friendly_or_synonym!(params[:id])
   end
 
   # Never trust parameters from the scary internet, only allow the white list through.

--- a/app/models/species.rb
+++ b/app/models/species.rb
@@ -288,6 +288,18 @@ class Species < ApplicationRecord
   extend FriendlyId
   friendly_id :scientific_name, use: :slugged
 
+  # Resolves a slug or id, falling back on the synonymy: a species merged
+  # into its accepted taxon keeps answering through the Synonym that
+  # replaced it, so stored slugs survive the merge.
+  def self.friendly_or_synonym!(param)
+    friendly.find(param)
+  rescue ActiveRecord::RecordNotFound
+    synonym = Synonym.find_by(record_type: 'Species', slug: param.to_s)
+    raise unless synonym&.record.is_a?(Species)
+
+    synonym.record
+  end
+
   after_save :setup_main_species
 
   auto_strip_attributes(*STRING_ATTRIBUTES, squish: true)

--- a/app/models/synonym.rb
+++ b/app/models/synonym.rb
@@ -10,11 +10,13 @@
 #  notes       :text
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#  slug        :string
 #
 # Indexes
 #
 #  index_synonyms_on_name                       (name)
 #  index_synonyms_on_record_type_and_record_id  (record_type,record_id)
+#  index_synonyms_on_slug                       (slug)
 #
 
 class Synonym < ApplicationRecord
@@ -27,6 +29,10 @@ class Synonym < ApplicationRecord
 
   auto_strip_attributes :author, :name, :notes
 
+  # Same derivation as a species slug, so the name keeps resolving through
+  # /species/:slug after a synonym-species record is merged away.
+  before_save :derive_slug
+
   counter_culture :record,
                   column_name: proc {|model| model.respond_to?(:synonyms_count) ? 'synonyms_count' : nil },
                   column_names: {
@@ -37,6 +43,10 @@ class Synonym < ApplicationRecord
 
   def have_different_name
     errors.add(:name, 'Must be different than the record') if record.respond_to?(:scientific_name) && (record.scientific_name == name)
+  end
+
+  def derive_slug
+    self.slug = name.to_s.parameterize if slug.blank? || will_save_change_to_name?
   end
 
   def self.auto_migrate

--- a/app/workers/migrators/synonym_slugs_worker.rb
+++ b/app/workers/migrators/synonym_slugs_worker.rb
@@ -1,0 +1,32 @@
+# Backfills synonyms.slug (same derivation as the before_save callback).
+# Replayable: only touches rows where the slug is missing or stale.
+class Migrators::SynonymSlugsWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: :migrations, retry: true, backtrace: true
+
+  def perform(*_args)
+    updated = 0
+
+    Synonym.where(slug: nil).find_in_batches(batch_size: 1000) do |batch|
+      pairs = batch.filter_map do |synonym|
+        slug = synonym.name.to_s.parameterize
+        [synonym.id, slug] if slug.present?
+      end
+      next if pairs.empty?
+
+      values = pairs.map do |id, slug|
+        "(#{id}, #{Synonym.connection.quote(slug)})"
+      end.join(', ')
+
+      Synonym.connection.execute(<<~SQL.squish)
+        UPDATE synonyms SET slug = v.slug
+        FROM (VALUES #{values}) AS v(id, slug)
+        WHERE synonyms.id = v.id
+      SQL
+      updated += pairs.size
+    end
+
+    Rails.logger.info("[SynonymSlugsWorker] backfilled #{updated} slugs")
+    updated
+  end
+end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -129,6 +129,16 @@
       "file": "app/controllers/management/user_queries_controller.rb",
       "line": 37,
       "note": "Management backoffice is admin-only (check_admin); admins editing user records is the feature."
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "083656b2b7c1c44b98ad4dd54b424dfa90bf0dc59de725ee7d276be96ba94d93",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/workers/migrators/synonym_slugs_worker.rb",
+      "line": 23,
+      "note": "Batch backfill of synonyms.slug: the VALUES list holds integer ids and connection.quote()d strings only."
     }
   ],
   "updated": "2026-09-03",

--- a/db/migrate/20260905160000_add_slug_to_synonyms.rb
+++ b/db/migrate/20260905160000_add_slug_to_synonyms.rb
@@ -1,0 +1,9 @@
+class AddSlugToSynonyms < ActiveRecord::Migration[8.0]
+  def change
+    # Lets a species slug keep resolving after the record is merged into its
+    # accepted taxon: the Synonym carries the name, the slug makes it
+    # addressable. Backfill: Migrators::SynonymSlugsWorker.
+    add_column :synonyms, :slug, :string
+    add_index :synonyms, :slug
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_09_05_053000) do
+ActiveRecord::Schema[8.0].define(version: 2026_09_05_160000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -660,8 +660,10 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_05_053000) do
     t.text "notes"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "slug"
     t.index ["name"], name: "index_synonyms_on_name"
     t.index ["record_type", "record_id"], name: "index_synonyms_on_record_type_and_record_id"
+    t.index ["slug"], name: "index_synonyms_on_slug"
   end
 
   create_table "user_queries", force: :cascade do |t|

--- a/spec/models/synonym_spec.rb
+++ b/spec/models/synonym_spec.rb
@@ -10,11 +10,13 @@
 #  notes       :text
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#  slug        :string
 #
 # Indexes
 #
 #  index_synonyms_on_name                       (name)
 #  index_synonyms_on_record_type_and_record_id  (record_type,record_id)
+#  index_synonyms_on_slug                       (slug)
 #
 
 require 'rails_helper'

--- a/spec/requests/api/v1/species_synonym_fallback_spec.rb
+++ b/spec/requests/api/v1/species_synonym_fallback_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+# A species record merged into its accepted taxon leaves a Synonym behind;
+# its slug must keep resolving so clients that stored it do not break.
+RSpec.describe 'Species synonym fallback', type: :request do
+
+  let(:user) { create(:user) }
+  let(:accepted) { Species.friendly.find('abies-alba') }
+  let!(:synonym) { Synonym.create!(record: accepted, name: 'Abies pectinata') }
+
+  describe 'Species.friendly_or_synonym!' do
+    it 'resolves a live slug to the species itself' do
+      expect(Species.friendly_or_synonym!('abies-alba')).to eq(accepted)
+    end
+
+    it 'falls back to the accepted species through the synonym slug' do
+      expect(synonym.slug).to eq('abies-pectinata')
+      expect(Species.friendly_or_synonym!('abies-pectinata')).to eq(accepted)
+    end
+
+    it 'still raises on unknown slugs' do
+      expect { Species.friendly_or_synonym!('no-such-species') }
+        .to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
+  it 'serves the accepted species on /api/v1/species/:synonym_slug' do
+    get '/api/v1/species/abies-pectinata', params: { token: user.token }
+
+    expect(response).to have_http_status(:ok)
+    expect(JSON.parse(response.body)['data']['slug']).to eq('abies-alba')
+  end
+
+  it 'serves the accepted plant on /api/v1/plants/:synonym_slug' do
+    get '/api/v1/plants/abies-pectinata', params: { token: user.token }
+
+    expect(response).to have_http_status(:ok)
+    expect(JSON.parse(response.body)['data']['slug']).to eq('abies-alba')
+  end
+
+  it 'serves the provenance facts through the synonym slug' do
+    SpeciesFact.record!(species: accepted, attribute_name: 'average_height_cm', source: 'powo', value: 250)
+
+    get '/api/v1/species/abies-pectinata/facts', params: { token: user.token }
+
+    expect(response).to have_http_status(:ok)
+    expect(JSON.parse(response.body)['meta']['total']).to eq(1)
+  end
+
+  it 'keeps answering 404 on unknown species' do
+    get '/api/v1/species/no-such-species', params: { token: user.token }
+
+    expect(response).to have_http_status(:not_found)
+  end
+
+  it 'renders the explore page through the synonym slug' do
+    get '/explore/species/abies-pectinata'
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include('Abies alba')
+  end
+
+end

--- a/spec/workers/migrators/synonym_slugs_worker_spec.rb
+++ b/spec/workers/migrators/synonym_slugs_worker_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe Migrators::SynonymSlugsWorker do
+
+  let(:species) { Species.friendly.find('abies-alba') }
+
+  it 'backfills missing slugs and leaves the rest alone' do
+    legacy = Synonym.create!(record: species, name: 'Abies pectinata')
+    legacy.update_columns(slug: nil) # rows that predate the column
+    fresh = Synonym.create!(record: species, name: 'Abies vulgaris')
+
+    expect(described_class.new.perform).to eq(1)
+
+    expect(legacy.reload.slug).to eq('abies-pectinata')
+    expect(fresh.reload.slug).to eq('abies-vulgaris')
+  end
+
+end


### PR DESCRIPTION
Preparation for merging the ~37k species records that are names some authority treats as synonyms (WCVP analysis): once such a record is merged into its accepted taxon and deleted, its **slug must keep resolving** for clients that stored it.

- `synonyms.slug` (indexed), derived from the name exactly like a species slug; existing rows backfilled by `Migrators::SynonymSlugsWorker` (replayable, batched).
- `Species.friendly_or_synonym!`: resolves a slug or id, and falls back on the Species synonymy when the slug no longer matches a live record. Used by the read endpoints — `GET /api/v1/species/:id`, `/api/v1/species/:id/facts`, `GET /api/v1/plants/:id`, and the explore page.
- Numeric ids of deleted records still answer 404 — only slugs survive the merge, through the Synonym that replaced the record.

Suite: 977 examples, 0 failures. RuboCop clean; the batched UPDATE of the backfill is fingerprinted in `config/brakeman.ignore` (integer ids + quoted strings only).