### PR TITLE
Bump rubyzip to 3.6.0 (CVE-2026-85396)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -528,7 +528,7 @@ GEM
     ruby-progressbar (1.13.0)
     ruby-statistics (4.1.0)
     ruby2_keywords (0.0.5)
-    rubyzip (3.2.2)
+    rubyzip (3.6.0)
     rufus-scheduler (3.9.2)
       fugit (~> 1.1, >= 1.11.1)
     searchkick (6.1.2)


### PR DESCRIPTION
Closes #310

## What

Bumps `rubyzip` from 3.2.2 to 3.6.0 in `Gemfile.lock` via `bundle update rubyzip --conservative`. No `Gemfile` change needed — it's a transitive test-only dependency pulled in by `selenium-webdriver` (constraint: `>= 1.2.2, < 4.0`), which already permits 3.x.

## Why

`bundler-audit` was red on every PR (CVE-2026-85396, path traversal, High) because of this preexisting advisory on `master`.

## Verification

- `bundler-audit check --update`: vulnerability reproduced before the bump, clean ("No vulnerabilities found") after.
- `bundle exec rspec`: 982 examples, 0 failures.
- `bundle exec rubocop`: 425 files inspected, no offenses.

Touches: Gemfile.lock