### PR TITLE
Institutional header and footer: mono wordmark, duotone nav icons, column footer

### DIFF
--- a/app/assets/javascripts/application.scss
+++ b/app/assets/javascripts/application.scss
@@ -12,6 +12,8 @@
 
 @import 'sections/home';
 @import 'sections/explore';
+@import 'sections/navbar';
+@import 'sections/footer';
 
 // Bulma's $title-family/$subtitle-family (sections/_variables.scss) cover
 // the .title/.subtitle helper components, but content.sass has no per-level

--- a/app/assets/javascripts/sections/_explore.scss
+++ b/app/assets/javascripts/sections/_explore.scss
@@ -159,6 +159,12 @@
   }
 }
 
+// Entry point back to the global corrections queue now that the navbar's
+// Explore dropdown (which used to link it) is gone (#312 review fix).
+.explore-corrections-link {
+  margin-top: 1em;
+}
+
 .species-grid-item {
   display: flex;
   align-items: stretch;

--- a/app/assets/javascripts/sections/_footer.scss
+++ b/app/assets/javascripts/sections/_footer.scss
@@ -1,0 +1,46 @@
+
+@import "variables";
+
+// Institutional footer (#304): DS Footer column layout — brand-colored
+// social links (previously hardcoded inline `style="color:..."`, now classes
+// per #304's cleanup) and the version credit request specs assert against
+// (a.app-revision / span.app-revision, spec/requests/web/home_spec.rb).
+.site-footer {
+  > .level {
+    align-items: flex-start;
+  }
+
+  .menu-label {
+    color: $forest-green;
+    font-size: $size-small;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+  }
+
+  &__social-link {
+    align-items: center;
+    display: flex;
+
+    span + span {
+      margin-left: 5px;
+    }
+
+    // Brand colors stay fixed on hover too, matching the previous inline
+    // `style="color:..."` behaviour (inline styles beat any :hover rule).
+    &--discord,
+    &--discord:hover {
+      color: #7289da;
+    }
+
+    &--twitter,
+    &--twitter:hover {
+      color: #55acee;
+    }
+
+    &--github,
+    &--github:hover {
+      color: #242a2f;
+    }
+  }
+}

--- a/app/assets/javascripts/sections/_footer.scss
+++ b/app/assets/javascripts/sections/_footer.scss
@@ -6,8 +6,15 @@
 // per #304's cleanup) and the version credit request specs assert against
 // (a.app-revision / span.app-revision, spec/requests/web/home_spec.rb).
 .site-footer {
-  > .level {
-    align-items: flex-start;
+  // Matches .site-navbar-container's 1040px override (#304 / #312 review) —
+  // the footer's link columns and version line now share the header's width
+  // instead of Bulma's default 960px desktop .container.
+  .site-footer-container {
+    max-width: $layout-max-width;
+
+    > .level {
+      align-items: flex-start;
+    }
   }
 
   .menu-label {

--- a/app/assets/javascripts/sections/_home.scss
+++ b/app/assets/javascripts/sections/_home.scss
@@ -65,27 +65,6 @@
   }
 }
 
-a.navbar-item {
-  font-family: $family-primary;
-  font-weight: 600;
-
-  i, .svg-inline--fa {
-    padding-right: 5px;
-  }
-}
-
-.footer > .level {
-  align-items: flex-start;
-}
-
-a.navbar-item.aligned-item {
-  display: flex;
-  align-items: center;
-  span + span {
-    margin-left: 5px;
-  }
-}
-
 .fakeButtons {
   height: 10px;
   width: 10px;

--- a/app/assets/javascripts/sections/_navbar.scss
+++ b/app/assets/javascripts/sections/_navbar.scss
@@ -6,6 +6,14 @@
 // stays Bulma's own navbar/navbar-burger/navbar-menu markup so the existing
 // mobile burger toggle (application.js) keeps working unmodified — only the
 // look is restyled here.
+// Bulma's own .container caps at 960px on desktop (see bulma/elements/
+// container.sass's $desktop - $container-offset); the maquette wants 1040px
+// (see #304 / #312 review) so this overrides it specifically for the navbar,
+// without touching .container's default elsewhere on the site.
+.site-navbar-container {
+  max-width: $layout-max-width;
+}
+
 .navbar.site-navbar {
   border-bottom: 1px solid #dbdbdb;
   min-height: 4rem;

--- a/app/assets/javascripts/sections/_navbar.scss
+++ b/app/assets/javascripts/sections/_navbar.scss
@@ -1,0 +1,70 @@
+
+@import "variables";
+
+// Institutional header (#304): mono wordmark next to the clover mark, plain
+// duotone-icon nav items in Noto Sans, single hairline border. Structure
+// stays Bulma's own navbar/navbar-burger/navbar-menu markup so the existing
+// mobile burger toggle (application.js) keeps working unmodified — only the
+// look is restyled here.
+.navbar.site-navbar {
+  border-bottom: 1px solid #dbdbdb;
+  min-height: 4rem;
+
+  .navbar-brand {
+    align-items: center;
+  }
+
+  .brand-link {
+    align-items: center;
+    display: flex;
+    gap: 0.6rem;
+  }
+
+  .brand-wordmark {
+    color: #0a0a0a;
+    font-family: $family-monospace;
+    font-size: 1.25rem;
+    font-weight: 500;
+    letter-spacing: -0.01em;
+  }
+
+  .navbar-item,
+  .navbar-link {
+    align-items: center;
+    color: #363636;
+    display: flex;
+    font-size: 0.9375rem;
+    font-weight: 600;
+    gap: 6px;
+    transition: color 150ms;
+
+    .fa-icon {
+      color: $forest-green;
+    }
+
+    &:hover,
+    &:focus,
+    &.has-text-link {
+      background: transparent;
+      color: $forest-green;
+    }
+  }
+
+  // "Sign in" is a plain link, not a nav item — no icon, no bold weight.
+  .navbar-signin {
+    font-weight: 400;
+  }
+
+  .navbar-account {
+    .user-image {
+      border-radius: 50%;
+      height: 1.5rem;
+      margin-right: 0;
+      width: 1.5rem;
+    }
+
+    &__sponsor {
+      color: #f39c12;
+    }
+  }
+}

--- a/app/assets/javascripts/sections/_variables.scss
+++ b/app/assets/javascripts/sections/_variables.scss
@@ -69,6 +69,10 @@ $menu-item-active-background-color: $green;
 $break-small: 480px;
 $break-large: 1024px;
 
+// The 2026 institutional layout's container width (maquette-home.html:39,
+// see #304), wider than Bulma's own desktop container default (960px).
+$layout-max-width: 1040px;
+
 @mixin respond-to($media) {
   @if $media == handhelds {
     @media only screen and (max-width: $break-small) { @content; }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -59,7 +59,6 @@ module ApplicationHelper
 
   def active_class_for(active_controller: nil, class_name: 'has-text-link')
     cname = "#{controller.class.to_s.underscore.gsub('_controller', '')}##{action_name}"
-    puts "cname: #{cname}"
     return class_name if active_controller && (cname == active_controller || cname =~ /#{active_controller}/)
 
     ''

--- a/app/views/explore/species/index.html.erb
+++ b/app/views/explore/species/index.html.erb
@@ -12,6 +12,11 @@
             <h2 class="subtitle">
               Browse and contribute to the Trefle botanical data.
             </h2>
+            <p class="explore-corrections-link">
+              <%= link_to(explore_record_corrections_path(status: :pending)) do %>
+                <%= fa_icon('clipboard-list-check', class: 'has-text-primary') %> Review the corrections queue
+              <% end %>
+            </p>
           </div>
         </div>
         <%= form_with(method: "get", local: true) do %>

--- a/app/views/layouts/_footer.erb
+++ b/app/views/layouts/_footer.erb
@@ -1,66 +1,60 @@
 
-<footer class="footer">
+<footer class="footer site-footer">
   <nav class="level">
     <div class="level-item">
       <aside class="menu">
         <p class="menu-label">
-          <a class="navbar-itemm" href="https://trefle.io">Trefle</a>
+          <a href="https://trefle.io">Trefle</a>
         </p>
         <ul class="menu-list">
           <li><%= link_to('About', about_path) %></li>
           <li><%= link_to('Terms', terms_path) %></li>
           <li>
             <% if user_signed_in? %>
-              <a class="navbar-itemm" title="Account" href="<%= profile_path %>">
-                Account
-              </a>
-              <% else %>
-              <a class="navbar-itemm" title="Sign in" href="<%= new_user_session_path %>">
-                Sign in
-              </a>
+              <%= link_to('Account', profile_path, title: 'Account') %>
+            <% else %>
+              <%= link_to('Sign in', new_user_session_path, title: 'Sign in') %>
             <% end %>
-            </li>
+          </li>
+          <li><%= link_to('Donate', donate_path) %></li>
         </ul>
       </aside>
     </div>
     <div class="level-item">
       <aside class="menu">
         <p class="menu-label">
-          <a class="navbar-itemm" href="https://docs.trefle.io">Documentation</a>
+          <a href="https://docs.trefle.io">Documentation</a>
         </p>
         <ul class="menu-list">
-          <li><a class="navbar-itemm" href="https://docs.trefle.io/docs/guides/getting-started">Getting started</a></li>
-          <li><a class="navbar-itemm" href="https://docs.trefle.io/reference">Reference</a></li>
-          <li><a class="navbar-itemm" href="https://docs.trefle.io/docs/examples/snippets">Snippets</a></li>
-          <li><a class="navbar-itemm" href="https://docs.trefle.io/blog/tags/releases">Releases</a></li>
+          <li><a href="https://docs.trefle.io/docs/guides/getting-started">Getting started</a></li>
+          <li><a href="https://docs.trefle.io/reference">Reference</a></li>
+          <li><a href="https://docs.trefle.io/docs/examples/snippets">Snippets</a></li>
+          <li><a href="https://docs.trefle.io/blog/tags/releases">Releases</a></li>
         </ul>
       </aside>
     </div>
     <div class="level-item">
       <aside class="menu">
         <p class="menu-label">
-          
         </p>
         <ul class="menu-list">
           <li>
-            <a class="navbar-item aligned-item" title="Join us on Discord" href="https://discord.gg/fuamwgk" target="_blank" rel="noopener">
-              <span class="icon" style="color: #7289da;">
-              <%= fa_icon('discord', style: :brands, class: 'fa-lg') %>
-              </span>
+            <a class="site-footer__social-link site-footer__social-link--discord" title="Join us on Discord" href="https://discord.gg/fuamwgk" target="_blank" rel="noopener">
+              <span class="icon"><%= fa_icon('discord', style: :brands, class: 'fa-lg') %></span>
               <span> Discord</span>
             </a>
           </li>
 
           <li>
-            <a class="navbar-item aligned-item" title="Join us on Twitter" href="https://twitter.com/trefle_api" target="_blank" rel="noopener">
-              <span class="icon" style="color: #55acee;"><%= fa_icon('twitter', style: :brands, class: 'fa-lg') %></span>
+            <a class="site-footer__social-link site-footer__social-link--twitter" title="Join us on Twitter" href="https://twitter.com/trefle_api" target="_blank" rel="noopener">
+              <span class="icon"><%= fa_icon('twitter', style: :brands, class: 'fa-lg') %></span>
               <span> Twitter</span>
             </a>
           </li>
 
           <li>
-            <a class="navbar-item aligned-item" title="Github" href="https://github.com/treflehq/trefle-api" target="_blank" rel="noopener">
-              <span class="icon" style="color: #242a2f;"><%= fa_icon('github', style: :brands, class: 'fa-lg') %></span>
+            <a class="site-footer__social-link site-footer__social-link--github" title="Github" href="https://github.com/treflehq/trefle-api" target="_blank" rel="noopener">
+              <span class="icon"><%= fa_icon('github', style: :brands, class: 'fa-lg') %></span>
               <span> Github</span>
             </a>
           </li>

--- a/app/views/layouts/_footer.erb
+++ b/app/views/layouts/_footer.erb
@@ -1,76 +1,78 @@
 
 <footer class="footer site-footer">
-  <nav class="level">
-    <div class="level-item">
-      <aside class="menu">
-        <p class="menu-label">
-          <a href="https://trefle.io">Trefle</a>
-        </p>
-        <ul class="menu-list">
-          <li><%= link_to('About', about_path) %></li>
-          <li><%= link_to('Terms', terms_path) %></li>
-          <li>
-            <% if user_signed_in? %>
-              <%= link_to('Account', profile_path, title: 'Account') %>
-            <% else %>
-              <%= link_to('Sign in', new_user_session_path, title: 'Sign in') %>
-            <% end %>
-          </li>
-          <li><%= link_to('Donate', donate_path) %></li>
-        </ul>
-      </aside>
-    </div>
-    <div class="level-item">
-      <aside class="menu">
-        <p class="menu-label">
-          <a href="https://docs.trefle.io">Documentation</a>
-        </p>
-        <ul class="menu-list">
-          <li><a href="https://docs.trefle.io/docs/guides/getting-started">Getting started</a></li>
-          <li><a href="https://docs.trefle.io/reference">Reference</a></li>
-          <li><a href="https://docs.trefle.io/docs/examples/snippets">Snippets</a></li>
-          <li><a href="https://docs.trefle.io/blog/tags/releases">Releases</a></li>
-        </ul>
-      </aside>
-    </div>
-    <div class="level-item">
-      <aside class="menu">
-        <p class="menu-label">
-        </p>
-        <ul class="menu-list">
-          <li>
-            <a class="site-footer__social-link site-footer__social-link--discord" title="Join us on Discord" href="https://discord.gg/fuamwgk" target="_blank" rel="noopener">
-              <span class="icon"><%= fa_icon('discord', style: :brands, class: 'fa-lg') %></span>
-              <span> Discord</span>
-            </a>
-          </li>
+  <div class="container site-footer-container">
+    <nav class="level">
+      <div class="level-item">
+        <aside class="menu">
+          <p class="menu-label">
+            <a href="https://trefle.io">Trefle</a>
+          </p>
+          <ul class="menu-list">
+            <li><%= link_to('About', about_path) %></li>
+            <li><%= link_to('Terms', terms_path) %></li>
+            <li>
+              <% if user_signed_in? %>
+                <%= link_to('Account', profile_path, title: 'Account') %>
+              <% else %>
+                <%= link_to('Sign in', new_user_session_path, title: 'Sign in') %>
+              <% end %>
+            </li>
+            <li><%= link_to('Donate', donate_path) %></li>
+          </ul>
+        </aside>
+      </div>
+      <div class="level-item">
+        <aside class="menu">
+          <p class="menu-label">
+            <a href="https://docs.trefle.io">Documentation</a>
+          </p>
+          <ul class="menu-list">
+            <li><a href="https://docs.trefle.io/docs/guides/getting-started">Getting started</a></li>
+            <li><a href="https://docs.trefle.io/reference">Reference</a></li>
+            <li><a href="https://docs.trefle.io/docs/examples/snippets">Snippets</a></li>
+            <li><a href="https://docs.trefle.io/blog/tags/releases">Releases</a></li>
+          </ul>
+        </aside>
+      </div>
+      <div class="level-item">
+        <aside class="menu">
+          <p class="menu-label">
+          </p>
+          <ul class="menu-list">
+            <li>
+              <a class="site-footer__social-link site-footer__social-link--discord" title="Join us on Discord" href="https://discord.gg/fuamwgk" target="_blank" rel="noopener">
+                <span class="icon"><%= fa_icon('discord', style: :brands, class: 'fa-lg') %></span>
+                <span> Discord</span>
+              </a>
+            </li>
 
-          <li>
-            <a class="site-footer__social-link site-footer__social-link--twitter" title="Join us on Twitter" href="https://twitter.com/trefle_api" target="_blank" rel="noopener">
-              <span class="icon"><%= fa_icon('twitter', style: :brands, class: 'fa-lg') %></span>
-              <span> Twitter</span>
-            </a>
-          </li>
+            <li>
+              <a class="site-footer__social-link site-footer__social-link--twitter" title="Join us on Twitter" href="https://twitter.com/trefle_api" target="_blank" rel="noopener">
+                <span class="icon"><%= fa_icon('twitter', style: :brands, class: 'fa-lg') %></span>
+                <span> Twitter</span>
+              </a>
+            </li>
 
-          <li>
-            <a class="site-footer__social-link site-footer__social-link--github" title="Github" href="https://github.com/treflehq/trefle-api" target="_blank" rel="noopener">
-              <span class="icon"><%= fa_icon('github', style: :brands, class: 'fa-lg') %></span>
-              <span> Github</span>
-            </a>
-          </li>
-        </ul>
-      </aside>
+            <li>
+              <a class="site-footer__social-link site-footer__social-link--github" title="Github" href="https://github.com/treflehq/trefle-api" target="_blank" rel="noopener">
+                <span class="icon"><%= fa_icon('github', style: :brands, class: 'fa-lg') %></span>
+                <span> Github</span>
+              </a>
+            </li>
+          </ul>
+        </aside>
+      </div>
+    </nav>
+    <div class="has-text-centered">
+      <p>
+        Trefle is backed by <a target="_blank" rel="noopener noreferrer" href="https://mashum.org">Mashum</a>
+        &middot;
+        <% if app_revision_url %>
+          <a class="app-revision" target="_blank" rel="noopener noreferrer" href="<%= app_revision_url %>"><%= app_revision %></a>
+        <% else %>
+          <span class="app-revision"><%= app_revision %></span>
+        <% end %>
+      </p>
     </div>
-  </nav>
-  <div class="container has-text-centered">
-    <p>
-      Trefle is backed by <a target="_blank" rel="noopener noreferrer" href="https://mashum.org">Mashum</a>
-      &middot;
-      <% if app_revision_url %>
-        <a class="app-revision" target="_blank" rel="noopener noreferrer" href="<%= app_revision_url %>"><%= app_revision %></a>
-      <% else %>
-        <span class="app-revision"><%= app_revision %></span>
-      <% end %>
-    </p>
   </div>
 </footer>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,4 +1,4 @@
-<div class="container">
+<div class="container site-navbar-container">
   <nav class="navbar site-navbar" role="navigation" aria-label="main navigation">
     <div class="navbar-brand">
       <a class="navbar-item brand-link" href="<%= root_path %>">

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,8 +1,9 @@
 <div class="container">
-  <nav class="navbar" role="navigation" aria-label="main navigation">
+  <nav class="navbar site-navbar" role="navigation" aria-label="main navigation">
     <div class="navbar-brand">
-      <a class="navbar-item" href="<%= root_path %>">
-        <%= image_tag(asset_path("logo.svg"), alt: "logo", height: "200") %>
+      <a class="navbar-item brand-link" href="<%= root_path %>">
+        <%= image_tag(asset_path("logo.svg"), alt: "Trefle") %>
+        <span class="brand-wordmark">trefle</span>
       </a>
 
       <a role="button" class="navbar-burger burger" aria-label="menu" aria-expanded="false" data-target="navbar-trefle">
@@ -14,108 +15,48 @@
 
     <div id="navbar-trefle" class="navbar-menu">
       <div class="navbar-start">
-
-          <div class="navbar-item has-dropdown is-hoverable">
-            <a class="navbar-item <%= active_class_for(active_controller: 'explore/*') %>" href="<%= explore_path %>">
-              <%= fa_icon('compass') %><span> Explore</span>
-            </a>
-
-            <div class="navbar-dropdown is-boxed">
-              <a class="navbar-item" href="<%= explore_path %>">
-                <%= fa_icon('search') %><span> Search</span>
-              </a>
-              <a class="navbar-item" href="<%= explore_record_corrections_path(status: :pending) %>">
-                <%= fa_icon('clipboard-list-check') %><span> Corrections</span>
-              </a>
-              <%
-=begin%>
- <a class="navbar-item" href="<%= explore_data_path %>">
-                <%= fa_icon('database') %><span> Downloads</span>
-              </a> 
-<%
-=end%>
-            </div>
-          </div>
-
-        <div class="navbar-item has-dropdown is-hoverable">
-          <a class="navbar-item " href="https://docs.trefle.io">
-            <%= fa_icon('book') %><span> Documentation</span>
-          </a>
-          <div class="navbar-dropdown is-boxed">
-            <a class="navbar-item" href="https://docs.trefle.io/docs/guides/getting-started">Getting started</a>
-            <a class="navbar-item" href="https://docs.trefle.io/reference">Reference</a>
-            <a class="navbar-item" href="https://docs.trefle.io/docs/examples/snippets">Snippets</a>
-            <a class="navbar-item" href="https://docs.trefle.io/blog/tags/releases">Releases</a>
-          </div>
-        </div>
-
-        <% if user_signed_in? && current_user.admin? %>
-        <a class="navbar-item " href="<%= management_path %>">
-          <%= fa_icon('key') %><span> Management</span>
+        <a class="navbar-item <%= active_class_for(active_controller: 'explore/*') %>" href="<%= explore_path %>">
+          <%= fa_icon('compass') %><span>Explore</span>
         </a>
-        <% end %>
+
+        <a class="navbar-item" href="https://docs.trefle.io">
+          <%= fa_icon('book') %><span>Documentation</span>
+        </a>
+
+        <a class="navbar-item" href="<%= root_path(anchor: 'data') %>">
+          <%= fa_icon('database') %><span>Data</span>
+        </a>
 
         <a class="navbar-item <%= active_class_for(active_controller: 'home#about') %>" href="<%= about_path %>">
-          <%= fa_icon('clipboard-user') %><span> About</span>
+          <%= fa_icon('clipboard-user') %><span>About</span>
         </a>
 
         <a class="navbar-item <%= active_class_for(active_controller: 'home#donate') %>" href="<%= donate_path %>">
-          <%= fa_icon('hand-holding-heart') %><span> Donate</span>
+          <%= fa_icon('hand-holding-heart') %><span>Donate</span>
         </a>
+
+        <% if user_signed_in? && current_user.admin? %>
+        <a class="navbar-item" href="<%= management_path %>">
+          <%= fa_icon('key') %><span>Management</span>
+        </a>
+        <% end %>
       </div>
 
       <div class="navbar-end">
         <% if user_signed_in? %>
-        <a class="navbar-item" title="Account" href="<%= profile_path() %>">
+        <a class="navbar-item navbar-account" title="Account" href="<%= profile_path %>">
           <%= image_tag current_user.gravatar_url, class: 'user-image' %>
-          <%= current_user.name || current_user.email %>
+          <span><%= current_user.name || current_user.email %></span>
           <% if current_user.sponsored_tier.present? %>
-            <span class="icon" style="color: #f39c12; margin-left: 5px"><%= fa_icon('crown') %></span>
+            <span class="icon navbar-account__sponsor"><%= fa_icon('crown') %></span>
           <% end %>
         </a>
-        <%
-=begin%>
-        <a class="navbar-item" title="Correct or add missing data" href="<%= root_path %>">
-          <b><%= fa_icon('hands-helping', style: :regular) %> Complete our data</b>
-        </a>
-        <%
-=end%>
         <% else %>
-        <a class="navbar-item" title="Sign in" href="<%= new_user_session_path %>">
+        <a class="navbar-item navbar-signin" title="Sign in" href="<%= new_user_session_path %>">
           Sign in
         </a>
-        <%
-=begin%>
-        <a class="navbar-item" title="Correct or add missing data" href="<%= new_user_session_path %>">
-          <b><%= fa_icon('hands-helping', style: :regular) %> Complete our data</b>
-        </a>
-        <%
-=end%>
         <% end %>
-
-        <a class="navbar-item is-hidden-desktop-only" title="Join us on Discord" href="https://discord.gg/fuamwgk" target="_blank">
-          <span class="icon" style="color: #7289da;"><%= fa_icon('discord', style: :brands, class: 'fa-lg') %></span>
-        </a>
-
-        <a class="navbar-item is-hidden-desktop-only" title="Join us on Twitter" href="https://twitter.com/trefle_api" target="_blank" rel="noopener">
-          <span class="icon" style="color: #55acee;"><%= fa_icon('twitter', style: :brands, class: 'fa-lg') %></span>
-        </a>
-        <%
-=begin%>
- <a class="navbar-item is-hidden-desktop-only" title="Github" href="https://github.com/treflehq/trefle-api" target="_blank" rel="noopener">
-          <span class="icon" style="color: #242a2f;"><%= fa_icon('github', style: :brands, class: 'fa-lg') %></span>
-        </a>
-<%
-=end%>
       </div>
     </div>
   </nav>
-  <%
-=begin%>
- <% if is_explore_namespace? %>
-    <hr/>
-    <%= render partial: 'explore/layouts/navbar' %>
-  <% end %>
-<%
-=end%>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -49,8 +49,6 @@
     </section>
     <%= render partial: "layouts/footer" %>
 
-    <%= javascript_include_tag 'application' %>
-
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-8VL7KHM5CK"></script>
     <script>
       window.dataLayer = window.dataLayer || [];


### PR DESCRIPTION
Closes #304

Reworks the shared layout chrome (`app/views/layouts/`) to the 2026 institutional maquette.

## Header
- Clover mark + lowercase `trefle` wordmark in Roboto Mono 500 (text, not baked into the image).
- Flat 5-item nav — Explore, Documentation, Data, About, Donate — each with its duotone icon in forest green. Drops the old Explore/Documentation dropdowns: Corrections stays reachable from within /explore, and the docs breadcrumbs (Getting started/Reference/Snippets/Releases) move to the footer's Documentation column.
- Plain right-aligned "Sign in" link; Account and Management links restyled consistently with the rest of the nav.
- Bulma's navbar/navbar-burger markup is untouched, so the existing mobile burger toggle (`application.js`) keeps working unmodified.

## Footer
- DS Footer column layout: Trefle (About, Terms, Account/Sign in, Donate), Documentation (Getting started, Reference, Snippets, Releases).
- Brand-colored social links (Discord/Twitter/GitHub) moved from inline `style=` colors to `site-footer__social-link--*` classes.
- Version credit (`a.app-revision` / `span.app-revision`) untouched — request specs still assert it.

## Cleanups
- Removed the dead `<%=begin%>` commented-out blocks in `_navbar.html.erb`.
- Removed the debug `puts "cname: ..."` in `ApplicationHelper#active_class_for` (was running on every navbar render).
- Removed the duplicate `javascript_include_tag "application"` — it was loaded once, deferred, in `<head>`, and a second time, undeferred, at the bottom of `<body>`.
- Superseded the ad-hoc navbar/footer rules in `sections/_home.scss` (`a.navbar-item`, `aligned-item`, `footer > .level`) with dedicated `sections/_navbar.scss` and `sections/_footer.scss`.

## Verification
- `bundle exec rspec` — 1025 examples, 0 failures.
- `bundle exec rubocop` — 0 offenses.
- `bundle exec brakeman` — 0 warnings.
- `yarn build` — clean (only pre-existing bundle-size warnings).
- Manually checked in a headless browser at desktop and mobile widths (home + about pages); screenshots match the maquette section-for-section for the header/footer.

Touches: app/views/layouts/, app/helpers/application_helper.rb, app/assets/javascripts/sections/, app/assets/javascripts/application.scss