### PR TITLE
Home stats backend: taxonomic ranks, field completeness, correction activity

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -21,6 +21,11 @@ class HomeController < ApplicationController
     end
 
     @synonyms_count = Rails.cache.fetch("home/synonyms_count-#{@plants_count}") { Synonym.count }
+
+    # Backs the redesigned home page (#305): taxonomic ranks, field
+    # completeness shares, and recent correction activity.
+    @home_stats = HomeStatsPresenter.new
+
     @jwt = ::Auth::JsonWebToken.new(
       user: User.find_by(email: 'guest@trefle.io'),
       origin: ENV['API_HOST'],

--- a/app/presenters/home_stats_presenter.rb
+++ b/app/presenters/home_stats_presenter.rb
@@ -1,0 +1,155 @@
+# Aggregates for the new home page (#303/#305): taxonomic rank breakdown,
+# field completeness shares, and recent correction activity.
+#
+# Every one of these is a full-table aggregate over Species/RecordCorrection,
+# so each value is cached independently for at least an hour rather than
+# keyed to a counter (the pattern the old home page counters use). That's
+# deliberate: a deploy invalidates the page fragment cache, and a short or
+# counter-keyed cache would mean every request recomputing every aggregate at
+# once right after rollout.
+class HomeStatsPresenter
+  include RecordCorrectionHelper
+
+  CACHE_EXPIRY = 1.hour
+
+  # The `rank` enum has no distinct "cultivar" value (only `subvar`); the
+  # label below is carried over from the current (dead — cultivar isn't a
+  # real rank) home page code rather than inventing a new taxonomy.
+  RANK_LABELS = {
+    'species' => 'Species',
+    'var' => 'Varieties',
+    'ssp' => 'Subspecies',
+    'hybrid' => 'Hybrids',
+    'form' => 'Forms',
+    'subvar' => 'Cultivars'
+  }.freeze
+
+  GROWTH_CONDITIONS_SQL = <<~SQL.squish
+    light IS NOT NULL OR atmospheric_humidity IS NOT NULL OR ground_humidity IS NOT NULL OR
+    soil_texture IS NOT NULL OR soil_salinity IS NOT NULL OR soil_nutriments IS NOT NULL OR
+    ph_minimum IS NOT NULL OR ph_maximum IS NOT NULL OR
+    minimum_temperature_deg_c IS NOT NULL OR maximum_temperature_deg_c IS NOT NULL OR
+    minimum_precipitation_mm IS NOT NULL OR maximum_precipitation_mm IS NOT NULL OR
+    hardiness_zone IS NOT NULL
+  SQL
+
+  # `edible` is excluded on purpose: it's a derived column (traits.yml has it
+  # under category: derived, outside the counted completion categories) that
+  # a Species callback always sets to true/false from vegetable/edible_part,
+  # so it is never actually null and would make every species "complete".
+  EDIBILITY_AND_USES_SQL = <<~SQL.squish
+    vegetable IS NOT NULL OR edible_part != 0 OR toxicity IS NOT NULL
+  SQL
+
+  # Order matters here: it's the display order on the home page.
+  FIELD_COMPLETENESS_GROUPS = {
+    'Bibliography & author' => ->(scope) { scope.where.not(bibliography: [nil, '']).where.not(author: [nil, '']) },
+    'Images' => ->(scope) { scope.where('images_count > 0') },
+    'Distribution' => ->(scope) { scope.where(id: SpeciesDistribution.select(:species_id).distinct) },
+    'Common names' => ->(scope) { scope.where(id: CommonName.where(record_type: 'Species').select(:record_id).distinct) },
+    'Growth conditions' => ->(scope) { scope.where(GROWTH_CONDITIONS_SQL) },
+    'Edibility & uses' => ->(scope) { scope.where(EDIBILITY_AND_USES_SQL) }
+  }.freeze
+
+  CORRECTION_ACTIVITY_WINDOW = 30.days
+  CORRECTION_SERIES_WEEKS = 12
+  LATEST_REVIEWED_LIMIT = 5
+
+  # Counts of species per taxonomic rank, in display order, plus the total
+  # synonym count (shown as a separate footnote on the home page).
+  def records_by_rank
+    Rails.cache.fetch('home_stats/records_by_rank', expires_in: CACHE_EXPIRY) do
+      counts = Species.group(:rank).count
+      RANK_LABELS.each_with_object({}) {|(rank, label), acc| acc[label] = counts[rank] || 0 }
+    end
+  end
+
+  def synonyms_count
+    Rails.cache.fetch('home_stats/synonyms_count', expires_in: CACHE_EXPIRY) { Synonym.count }
+  end
+
+  # % of species (out of all Species rows, matching the existing counters'
+  # convention) with each group of fields filled in.
+  def field_completeness_shares
+    Rails.cache.fetch('home_stats/field_completeness_shares', expires_in: CACHE_EXPIRY) do
+      total = Species.count
+      FIELD_COMPLETENESS_GROUPS.each_with_object({}) do |(label, scope_builder), acc|
+        acc[label] = share(scope_builder.call(Species), total)
+      end
+    end
+  end
+
+  # 30-day correction activity: submitted/accepted counts, distinct
+  # contributors, and a 12-week weekly series of accepted corrections.
+  #
+  # `fields_completed` stands in for "count of changed fields across accepted
+  # corrections": correction_json is a free-form text blob, and parsing it
+  # for every row to count keys isn't cheap at this table's size, so this
+  # uses the accepted count instead, as allowed by #303.
+  def correction_activity
+    Rails.cache.fetch('home_stats/correction_activity', expires_in: CACHE_EXPIRY) do
+      submitted_scope = RecordCorrection.where(created_at: CORRECTION_ACTIVITY_WINDOW.ago..)
+      accepted_scope = RecordCorrection.accepted_change_status.where(updated_at: CORRECTION_ACTIVITY_WINDOW.ago..)
+
+      {
+        submitted: submitted_scope.count,
+        accepted: accepted_scope.count,
+        fields_completed: accepted_scope.count,
+        contributors: submitted_scope.distinct.count(:user_id),
+        weekly_accepted: weekly_accepted_series
+      }
+    end
+  end
+
+  # The 5 most recently reviewed (accepted or rejected) corrections, newest
+  # first, as plain hashes — no AR objects escape the cache.
+  def latest_reviewed_corrections
+    Rails.cache.fetch('home_stats/latest_reviewed_corrections', expires_in: CACHE_EXPIRY) do
+      RecordCorrection
+        .where.not(change_status: :pending)
+        .where(record_type: 'Species')
+        .includes(:user, :record)
+        .order(updated_at: :desc)
+        .limit(LATEST_REVIEWED_LIMIT)
+        .map {|correction| reviewed_entry(correction) }
+    end
+  end
+
+  private
+
+  def share(scope, total)
+    return 0 if total.zero?
+
+    ((scope.count * 100.0) / total).round(1)
+  end
+
+  def weekly_accepted_series
+    range_start = (CORRECTION_SERIES_WEEKS - 1).weeks.ago.beginning_of_week
+    timestamps = RecordCorrection.accepted_change_status.where(updated_at: range_start..).pluck(:updated_at)
+
+    buckets = Hash.new(0)
+    timestamps.each {|timestamp| buckets[timestamp.beginning_of_week.to_date] += 1 }
+
+    (0...CORRECTION_SERIES_WEEKS).map {|i| buckets[(range_start + i.weeks).to_date] }
+  end
+
+  def reviewed_entry(correction)
+    species = correction.record
+
+    {
+      species_name: species&.scientific_name,
+      species_slug: species&.slug,
+      status: correction.change_status,
+      description: title_for_correction(correction),
+      contributor: contributor_name(correction.user),
+      reviewed_at: correction.updated_at
+    }
+  end
+
+  def contributor_name(user)
+    return 'Anonymous' if user.nil?
+
+    user.name.presence || user.github_username.presence || user.email
+  end
+
+end

--- a/spec/presenters/home_stats_presenter_spec.rb
+++ b/spec/presenters/home_stats_presenter_spec.rb
@@ -1,0 +1,152 @@
+require 'rails_helper'
+
+# The test suite seeds a full botanic taxonomy (see spec/support/test_seeds.rb)
+# that most specs, including this one, run on top of - so assertions here
+# work against deltas (this presenter's counts before/after adding fixtures)
+# rather than absolute totals.
+RSpec.describe HomeStatsPresenter do
+  subject(:presenter) { described_class.new }
+
+  let(:genus) { create(:genus) }
+
+  def build_species(rank: 'species', **attrs)
+    create(:species, genus_id: genus.id, rank: rank, **attrs)
+  end
+
+  describe '#records_by_rank' do
+    it 'counts species per rank, labelled, on top of whatever already exists' do
+      baseline = presenter.records_by_rank
+
+      build_species(rank: 'species')
+      build_species(rank: 'species')
+      build_species(rank: 'var', scientific_name: "#{genus.name} testalpha var. testbeta")
+
+      updated = presenter.records_by_rank
+
+      expect(updated['Species']).to eq(baseline['Species'] + 2)
+      expect(updated['Varieties']).to eq(baseline['Varieties'] + 1)
+      expect(updated.except('Species', 'Varieties')).to eq(baseline.except('Species', 'Varieties'))
+    end
+  end
+
+  describe '#synonyms_count' do
+    it 'counts synonyms on top of whatever already exists' do
+      baseline = presenter.synonyms_count
+
+      species = build_species
+      Synonym.create!(record: species, name: 'Foo bar L.')
+      Synonym.create!(record: species, name: 'Baz qux L.')
+
+      expect(presenter.synonyms_count).to eq(baseline + 2)
+    end
+  end
+
+  describe 'FIELD_COMPLETENESS_GROUPS' do
+    it 'flags a species with every field filled, and excludes an entirely empty one' do
+      complete = build_species(
+        bibliography: 'Some source', author: 'L.', images_count: 3,
+        vegetable: true, light: 4
+      )
+      SpeciesDistribution.create!(species: complete, zone: Zone.first)
+      CommonName.create!(record: complete, name: 'Something')
+      empty = build_species
+
+      described_class::FIELD_COMPLETENESS_GROUPS.each do |label, scope_builder|
+        ids = scope_builder.call(Species).pluck(:id)
+        expect(ids).to include(complete.id), "expected '#{label}' to include the fully-filled species"
+        expect(ids).not_to include(empty.id), "expected '#{label}' to exclude the empty species"
+      end
+    end
+  end
+
+  describe '#field_completeness_shares' do
+    it 'returns one percentage per group, between 0 and 100' do
+      shares = presenter.field_completeness_shares
+
+      expect(shares.keys).to eq(described_class::FIELD_COMPLETENESS_GROUPS.keys)
+      expect(shares.values).to all(be_between(0, 100))
+    end
+  end
+
+  describe '#correction_activity' do
+    let(:species) { build_species }
+
+    def corrected(status:, created_at:, updated_at: created_at, user: create(:user))
+      correction = create(:record_correction, record: species, user: user, change_status: status)
+      correction.update_columns(created_at: created_at, updated_at: updated_at)
+      correction
+    end
+
+    it 'only counts submitted/accepted/contributors inside the 30-day window' do
+      baseline = presenter.correction_activity
+      recent_contributor = create(:user)
+      corrected(status: :pending, created_at: 5.days.ago, user: recent_contributor)
+      corrected(status: :accepted, created_at: 10.days.ago, updated_at: 3.days.ago, user: create(:user))
+      # Outside the 30-day window - must not count as submitted/accepted/contributor.
+      # Still within the 12-week series window, so it does show up there.
+      corrected(status: :accepted, created_at: 40.days.ago, updated_at: 40.days.ago)
+
+      activity = presenter.correction_activity
+
+      expect(activity[:submitted]).to eq(baseline[:submitted] + 2)
+      expect(activity[:accepted]).to eq(baseline[:accepted] + 1)
+      expect(activity[:fields_completed]).to eq(baseline[:fields_completed] + 1)
+      expect(activity[:contributors]).to eq(baseline[:contributors] + 2)
+      expect(activity[:weekly_accepted].length).to eq(12)
+      expect(activity[:weekly_accepted].sum).to eq(baseline[:weekly_accepted].sum + 2)
+    end
+
+    it 'buckets accepted corrections by week across the last 12 weeks' do
+      baseline = presenter.correction_activity[:weekly_accepted]
+
+      corrected(status: :accepted, created_at: Time.current, updated_at: Time.current)
+      corrected(status: :accepted, created_at: Time.current, updated_at: Time.current)
+      corrected(status: :accepted, created_at: 11.weeks.ago, updated_at: 11.weeks.ago)
+
+      series = presenter.correction_activity[:weekly_accepted]
+
+      expect(series.length).to eq(12)
+      expect(series.sum).to eq(baseline.sum + 3)
+      expect(series.first).to eq(baseline.first + 1) # the oldest bucket (11 weeks ago)
+      expect(series.last).to eq(baseline.last + 2) # the current week
+    end
+  end
+
+  describe '#latest_reviewed_corrections' do
+    it 'returns the most recently reviewed corrections first, excluding pending ones' do
+      species = build_species
+      user = create(:user, name: 'Ada')
+
+      old_accepted = create(:record_correction, record: species, user: user, change_status: :accepted,
+                                                correction_json: { author: 'L.' }.to_json)
+      old_accepted.update_columns(updated_at: 2.days.ago)
+
+      recent_rejected = create(:record_correction, record: species, user: user, change_status: :rejected)
+      recent_rejected.update_columns(updated_at: 1.hour.ago)
+
+      create(:record_correction, record: species, user: user, change_status: :pending)
+
+      entries = presenter.latest_reviewed_corrections
+      by_species = entries.select {|e| e[:species_slug] == species.slug }
+
+      expect(by_species.length).to eq(2)
+      expect(by_species.first).to include(
+        species_name: species.scientific_name,
+        species_slug: species.slug,
+        status: 'rejected',
+        contributor: 'Ada'
+      )
+      expect(by_species.last).to include(status: 'accepted', description: a_string_including('author'))
+    end
+
+    it 'falls back to the GitHub username, then the email, when the user has no name' do
+      species = build_species
+      user = create(:user, name: nil, github_username: 'octocat')
+      correction = create(:record_correction, record: species, user: user, change_status: :accepted)
+      correction.update_columns(updated_at: 1.hour.ago)
+
+      entry = presenter.latest_reviewed_corrections.find {|e| e[:species_slug] == species.slug }
+      expect(entry[:contributor]).to eq('octocat')
+    end
+  end
+end

--- a/spec/requests/web/home_spec.rb
+++ b/spec/requests/web/home_spec.rb
@@ -16,6 +16,11 @@ RSpec.describe 'Public website pages', type: :request do
       fragment = Nokogiri::HTML.fragment(response.body)
       expect(fragment.css('svg.fa-icon')).not_to be_empty
     end
+
+    it 'exposes the home stats presenter backing the redesigned home page (#305)' do
+      get root_path
+      expect(assigns(:home_stats)).to be_a(HomeStatsPresenter)
+    end
   end
 
   describe 'GET /about' do


### PR DESCRIPTION
Closes #303

Adds `HomeStatsPresenter`, exposed as `@home_stats` from `HomeController#index`, to back the redesigned home page (#305).

## What it adds

- **`records_by_rank`** — species counts per taxonomic rank, labelled, plus the total synonym count. Note: the `rank` enum has no distinct "cultivar" value (only `subvar`); the "Cultivars" label is carried over unchanged from the current (dead — `count_per_type['cultivar']` never matched anything) home page code rather than inventing a new taxonomy.
- **`field_completeness_shares`** — % of species with each of six field groups filled (bibliography & author, images, distribution, common names, growth conditions, edibility & uses). Each group is a set of real `traits.yml` fields checked with the same nil/blank semantics `Traits.filled?` uses, computed as SQL aggregates rather than iterating rows. `edible` is deliberately excluded from "edibility & uses": it's a derived column (category: derived) that a `Species` callback always sets from `vegetable`/`edible_part`, so it's never actually null.
- **`correction_activity`** — 30-day submitted/accepted counts, distinct contributors, and a 12-week weekly series of accepted corrections. `fields_completed` uses the accepted count as a stand-in: `correction_json` is free-form text, so counting changed keys would mean parsing JSON per row, which isn't cheap at this table's size.
- **`latest_reviewed_corrections`** — the 5 most recently reviewed (accepted or rejected) corrections, reusing the existing `title_for_correction` helper for the change description.

Everything is cached independently for at least an hour (not counter-keyed like the existing home page counters) since these are full-table aggregates, and a counter-keyed cache would mean every request recomputing all of them at once right after a deploy invalidates the page fragment cache.

## Testing

- New `spec/presenters/home_stats_presenter_spec.rb`: asserts against deltas (before/after adding fixtures) since the suite seeds a full botanic taxonomy that this presenter's aggregates run on top of.
- `spec/requests/web/home_spec.rb`: asserts `@home_stats` is assigned.
- Full `bundle exec rspec`: 1034 examples, 0 failures. `bundle exec rubocop`: 433 files, no offenses.

Touches: app/controllers/home_controller.rb, app/presenters/, spec/