### PR TITLE
Home: edge-to-edge rendering, changes-section fixes, yarn pin

### DIFF
--- a/app/assets/javascripts/sections/_home.scss
+++ b/app/assets/javascripts/sections/_home.scss
@@ -165,6 +165,7 @@
   letter-spacing: -0.01em;
   margin: 0;
   max-width: 20ch;
+  text-wrap: balance;
 }
 
 // The maquette sets font-style:italic on this <p> but wraps its text in a
@@ -186,6 +187,7 @@
   line-height: 1.6;
   margin: 1.75rem 0 0;
   max-width: 60ch;
+  text-wrap: pretty;
 }
 
 // Start here strip -------------------------------------------------------
@@ -299,6 +301,7 @@
     color: #7a7a7a;
     margin: 0.5rem 0 0;
     max-width: 60ch;
+    text-wrap: pretty;
   }
 }
 
@@ -424,14 +427,21 @@
 }
 
 .home-sparkline {
-  align-items: end;
   border-bottom: 1px solid #dbdbdb;
   display: grid;
   gap: 4px;
   grid-template-columns: repeat(12, minmax(0, 1fr));
   height: 120px;
 
-  &__bar {
+  // Same track/fill pairing as .home-bar-track above, so a quiet week reads
+  // as "zero on a chart" rather than "broken bar".
+  &__col {
+    align-items: end;
+    background: #e3f3e6;
+    display: grid;
+  }
+
+  &__fill {
     background: $forest-green;
     min-height: 2px;
   }
@@ -444,6 +454,12 @@
     justify-content: space-between;
     margin-top: 0.5rem;
   }
+
+  &__empty {
+    color: #7a7a7a;
+    font-size: 0.875rem;
+    margin: 0.75rem 0 0;
+  }
 }
 
 .home-reviewed-list {
@@ -453,19 +469,23 @@
   margin: 0;
   padding: 0;
 
+  // Grid, not flex: the meta column (contributor · date) is capped and
+  // ellipsized so a long contributor name can never crush the body column
+  // into a one-word-per-line sliver.
   &__item {
     align-items: baseline;
     border-top: 1px solid #dbdbdb;
-    display: flex;
+    display: grid;
     font-size: 0.875rem;
-    gap: 0.75rem;
+    gap: 0.25rem 0.75rem;
+    grid-template-columns: auto minmax(0, 1fr) auto;
     line-height: 1.4;
     padding: 0.5rem 0;
   }
 
   &__body {
-    flex: 1 1 auto;
     min-width: 0;
+    overflow-wrap: anywhere; // long field names (minimum_temperature_deg_c…)
   }
 
   &__species {
@@ -475,9 +495,22 @@
 
   &__meta {
     color: #7a7a7a;
-    flex: 0 0 auto;
     font-size: 0.75rem;
+    max-width: 13rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
     white-space: nowrap;
+  }
+
+  @include respond-to(handhelds) {
+    &__item {
+      grid-template-columns: auto minmax(0, 1fr);
+    }
+
+    &__meta {
+      grid-column: 2;
+      max-width: none;
+    }
   }
 }
 
@@ -538,6 +571,8 @@
   margin: 0.25rem 0 0;
   overflow-x: auto;
   padding: 0.75rem 1rem;
+  scrollbar-color: #7a7a7a transparent;
+  scrollbar-width: thin;
   white-space: pre;
 }
 
@@ -667,6 +702,13 @@
 .home-terminal {
   border-radius: 5px;
   overflow: hidden;
+
+  // The command line and JSON block are react-syntax-highlighter <pre>s;
+  // keep their overflow scrollbars discreet inside the dark terminal.
+  pre {
+    scrollbar-color: #7a7a7a #363636;
+    scrollbar-width: thin;
+  }
 
   &__bar {
     background: #444643;

--- a/app/views/home/_changes.html.erb
+++ b/app/views/home/_changes.html.erb
@@ -29,15 +29,23 @@
     <div class="home-changes-grid">
       <div>
         <h3 class="home-subheading">Accepted corrections per week</h3>
-        <div class="home-sparkline">
+        <% total_accepted = activity[:weekly_accepted].sum %>
+        <div class="home-sparkline" role="img" aria-label="<%= pluralize(total_accepted, 'correction') %> accepted over the last 12 weeks">
           <% activity[:weekly_accepted].each do |count| %>
-            <div class="home-sparkline__bar" style="height: <%= (count.to_f / max_weekly * 100).round(1) %>%"></div>
+            <div class="home-sparkline__col">
+              <% if count.positive? %>
+                <div class="home-sparkline__fill" style="height: <%= (count.to_f / max_weekly * 100).round(1) %>%"></div>
+              <% end %>
+            </div>
           <% end %>
         </div>
         <div class="home-sparkline__axis">
           <span>12 weeks ago</span>
           <span>this week</span>
         </div>
+        <% if total_accepted.zero? %>
+          <p class="home-sparkline__empty">No corrections accepted in the last 12 weeks.</p>
+        <% end %>
       </div>
 
       <div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,3 +1,8 @@
+<%# Sections manage their own container/washes edge to edge (maquette),
+    so the layout must not wrap this page in a padded Bulma .section.
+    Kept outside the cache block: content_for is a side effect that a
+    cached fragment would not replay. %>
+<% provide :full_bleed, '1' %>
 <% cache [:home, :index, TrefleAdmin::Application::VERSION, current_user.nil?, current_user&.admin] do %>
   <div class="home-page">
     <%= render 'home/hero' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,14 +40,18 @@
     }
   </script>
 
-  <p class="top-notification alert alert-info" role="alert""><%= notice %></p>
-  <p class=" top-notification alert alert-danger" role="alert""><%= alert %></p>
+  <p class="top-notification alert alert-info" role="alert"><%= notice %></p>
+  <p class="top-notification alert alert-danger" role="alert"><%= alert %></p>
 
   <%= render partial: "layouts/navbar" %>
-  <section class=" section">
+  <% if content_for?(:full_bleed) %>
     <%= yield %>
+  <% else %>
+    <section class="section">
+      <%= yield %>
     </section>
-    <%= render partial: "layouts/footer" %>
+  <% end %>
+  <%= render partial: "layouts/footer" %>
 
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-8VL7KHM5CK"></script>
     <script>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,11 @@
 {
   "name": "trefle-admin",
   "private": true,
+  "packageManager": "yarn@1.22.22",
+  "volta": {
+    "node": "24.18.0",
+    "yarn": "1.22.22"
+  },
   "dependencies": {
     "@babel/core": "^7.20.5",
     "@babel/preset-env": "^7.20.2",


### PR DESCRIPTION
Follow-up to #314 (the #305 home rebuild), after checking the rendered page in a browser against the maquette.

## What was wrong

- The layout wraps every page in a padded Bulma `.section`, so the home could not bleed its section washes to the viewport edge and the hero picked up double padding. **The mockup's edge-to-edge bands were impossible by construction.**
- With a quiet database, the corrections sparkline rendered as twelve 2px slivers — it looked broken rather than calm.
- A long contributor name (nowrap, flex) crushed the "Latest reviewed" body column into a one-word-per-line sliver, overlapping the species name.
- Stray thick scrollbars under the terminal command line and the curl sample.
- Two malformed attributes in the layout (`class=" section"`, `role="alert""`).

## Changes

- Home opts out of the layout wrapper via `content_for :full_bleed` (declared outside the fragment cache — content_for is a side effect a cached fragment would not replay). All other pages keep the wrapper; /about, /explore and Devise pages verified visually.
- Reviewed list: flex → grid (`auto minmax(0,1fr) auto`), meta column ellipsized and capped, body uses `overflow-wrap: anywhere`; stacks below 480px.
- Sparkline: track/fill pairing consistent with the data bars, `role="img"` + aria-label, and an explicit "No corrections accepted in the last 12 weeks." empty state.
- Thin scrollbars on the terminal `pre`s and the curl sample; `text-wrap: balance/pretty` on hero and section headings.
- `package.json`: pin `yarn@1.22.22` (volta + packageManager) — volta's default yarn 4 refuses the v1 lockfile and has tripped two local builds.

## Verification

- Checked in Chrome at desktop and narrow widths against `Trefle Home.dc.html`: hero spacing, full-bleed washes, start-here strip, live demo, data bars, changes section, footer.
- No horizontal page overflow (`scrollWidth == clientWidth` at minimum window width); only the terminal code scrolls, internally.
- RSpec: 1039 examples, 0 failures. RuboCop: 435 files, no offenses. `yarn build`: clean.

Touches: app/views/layouts/, app/views/home/, app/assets/javascripts/sections/, package.json