### PR TITLE
Explore: rebuild the browse page to the institutional maquette

### DIFF
--- a/app/assets/javascripts/sections/_explore.scss
+++ b/app/assets/javascripts/sections/_explore.scss
@@ -556,3 +556,278 @@
     margin-left: .5em;
   }
 }
+
+// ---------------------------------------------------------------------------
+// Explore browse page, rebuilt from Trefle Explore.dc.html
+// (.agents/design/home-2026/maquette-explore.html): full-bleed sections,
+// filter chips, sortable results grid with completeness meta, contribute band.
+
+.explore-header {
+  &__inner {
+    box-sizing: border-box;
+    margin: 0 auto;
+    max-width: $layout-max-width;
+    padding: 4rem 1.5rem 2rem;
+  }
+
+  &__heading {
+    align-items: flex-start;
+    display: flex;
+    gap: 0.75rem;
+  }
+
+  &__icon {
+    color: $forest-green;
+    display: inline-flex;
+    font-size: 2rem;
+    line-height: 1;
+    margin-top: 0.5rem;
+  }
+
+  &__title {
+    color: #0a0a0a;
+    font-family: $family-serif;
+    font-size: clamp(2.5rem, 5vw, 3.5rem);
+    font-weight: 500;
+    line-height: 1.05;
+    margin: 0;
+  }
+
+  &__intro {
+    color: #7a7a7a;
+    margin: 0.5rem 0 0;
+    max-width: 60ch;
+    text-wrap: pretty;
+  }
+}
+
+.explore-search {
+  margin-top: 2rem;
+  max-width: 640px;
+}
+
+.explore-filters {
+  align-items: flex-start;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem 2.5rem;
+  margin-top: 1.5rem;
+
+  &__group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+
+  &__label {
+    color: #7a7a7a;
+    font-family: $family-monospace;
+    font-size: 0.6875rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  &__chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.375rem;
+  }
+}
+
+.explore-chip {
+  background: #fff;
+  border: 1px solid #dbdbdb;
+  border-radius: 4px;
+  color: #363636;
+  font-size: 0.8125rem;
+  line-height: 1;
+  padding: 0.45rem 0.7rem;
+
+  &:hover,
+  &:focus {
+    border-color: $forest-green;
+    color: $forest-green;
+    text-decoration: none;
+  }
+
+  &--active {
+    background: $forest-green;
+    border-color: $forest-green;
+    color: #fff;
+    font-weight: 600;
+
+    &:hover,
+    &:focus {
+      background: darken($forest-green, 5%);
+      color: #fff;
+    }
+  }
+}
+
+.explore-results {
+  border-top: 1px solid #dbdbdb;
+
+  &__inner {
+    box-sizing: border-box;
+    margin: 0 auto;
+    max-width: $layout-max-width;
+    padding: 1.5rem 1.5rem 4rem;
+  }
+
+  &__header {
+    align-items: baseline;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    justify-content: space-between;
+  }
+
+  &__count {
+    color: #363636;
+    font-size: 0.9375rem;
+    margin: 0;
+  }
+}
+
+.explore-sort {
+  align-items: center;
+  display: flex;
+  gap: 0.5rem;
+
+  &__label {
+    color: #7a7a7a;
+    font-size: 0.875rem;
+  }
+}
+
+.explore-grid {
+  display: grid;
+  gap: 2rem 1.5rem;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  margin-top: 1.5rem;
+
+  &__cell {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+
+  &__meta {
+    align-items: center;
+    color: #7a7a7a;
+    display: flex;
+    font-size: 0.75rem;
+    gap: 0.5rem;
+    justify-content: space-between;
+    margin-top: 0.25rem;
+  }
+
+  &__family {
+    font-family: $family-monospace;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &__completeness {
+    align-items: center;
+    display: inline-flex;
+    flex: 0 0 auto;
+    gap: 0.35rem;
+  }
+
+  &__completeness-track {
+    background: #e3f3e6;
+    display: inline-block;
+    height: 4px;
+    overflow: hidden;
+    width: 40px;
+  }
+
+  &__completeness-fill {
+    background: $forest-green;
+    display: block;
+    height: 100%;
+  }
+
+  &__completeness-value {
+    font-family: $family-monospace;
+  }
+}
+
+.explore-pagination {
+  border-top: 1px solid #dbdbdb;
+  margin-top: 3rem;
+  padding-top: 1.5rem;
+}
+
+.explore-empty {
+  max-width: 52ch;
+  padding: 3rem 0;
+
+  &__title {
+    color: #0a0a0a;
+    font-family: $family-serif;
+    font-size: 1.75rem;
+    margin: 0;
+  }
+
+  &__hint {
+    color: #7a7a7a;
+    margin: 0.5rem 0 0;
+    text-wrap: pretty;
+  }
+}
+
+.explore-contribute {
+  background: #f5f5f5;
+  border-top: 1px solid #dbdbdb;
+
+  &__inner {
+    align-items: start;
+    box-sizing: border-box;
+    display: grid;
+    gap: 2rem 3rem;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    margin: 0 auto;
+    max-width: $layout-max-width;
+    padding: 3rem 1.5rem;
+  }
+
+  &__heading {
+    align-items: flex-start;
+    display: flex;
+    gap: 0.75rem;
+  }
+
+  &__icon {
+    color: $forest-green;
+    display: inline-flex;
+    font-size: 1.5rem;
+    line-height: 1;
+    margin-top: 0.3rem;
+  }
+
+  &__title {
+    color: #0a0a0a;
+    font-family: $family-serif;
+    font-size: 2rem;
+    font-weight: 500;
+    line-height: 1.1;
+    margin: 0;
+  }
+
+  &__body {
+    font-size: 0.9375rem;
+    margin: 0;
+    text-wrap: pretty;
+  }
+
+  &__ctas {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: 1.25rem;
+  }
+}

--- a/app/controllers/explore/species_controller.rb
+++ b/app/controllers/explore/species_controller.rb
@@ -1,8 +1,11 @@
 class Explore::SpeciesController < Explore::ExploreController
   before_action :set_species, only: %i[show edit update destroy refresh corrections]
 
-  has_scope :vegetable, type: :boolean, allow_blank: true
-  has_scope :edible, type: :boolean, allow_blank: true
+  # Browse filters, all optional and combinable with the search box. Ranks are
+  # the Species enum keys; flags map a param to a SQL/search condition.
+  FILTER_FLAGS = %w[images edible vegetable].freeze
+  SORTS = %w[name complete recent].freeze
+  FAMILY_CHIPS_COUNT = 7
 
   # GET /species
   # GET /species.json
@@ -10,15 +13,18 @@ class Explore::SpeciesController < Explore::ExploreController
     search = params[:search]
     @page_title = 'Explore plants and species'
     @page_keywords = 'explore, plants, search, species'
+    @family_chips = family_chips
 
     if search.blank?
-      @collection ||= Species.all.preload(:plant, :genus, :synonyms).order(wiki_score: :desc)
+      @collection = apply_filters(Species.all).preload(:plant, :genus, :synonyms).order(browse_order)
       @pagy, @collection = pagy(@collection)
     else
       options = {
         includes: %i[synonyms genus plant],
         boost_by: [:gbif_score],
-        fields: ['common_name^10', 'common_names^8', 'scientific_name^5', 'synonyms^3', 'author', 'genus', 'family', 'family_common_name', 'distributions']
+        fields: ['common_name^10', 'common_names^8', 'scientific_name^5', 'synonyms^3', 'author', 'genus', 'family', 'family_common_name', 'distributions'],
+        where: search_where,
+        order: search_order
       }.compact
 
       @collection = Species.pagy_search(search, **options)
@@ -107,6 +113,77 @@ class Explore::SpeciesController < Explore::ExploreController
   # end
 
   private
+
+  def current_rank
+    params[:rank] if Species.ranks.key?(params[:rank])
+  end
+  helper_method :current_rank
+
+  def current_family
+    params[:family].presence
+  end
+  helper_method :current_family
+
+  def current_flags
+    FILTER_FLAGS.select {|f| params[f] == '1' }
+  end
+  helper_method :current_flags
+
+  def current_sort
+    params[:sort] if SORTS.include?(params[:sort])
+  end
+  helper_method :current_sort
+
+  def apply_filters(scope)
+    scope = scope.where(rank: current_rank) if current_rank
+    scope = scope.where(family_name: current_family) if current_family
+    scope = scope.where.not(main_image_url: nil) if current_flags.include?('images')
+    scope = scope.where(edible: true) if current_flags.include?('edible')
+    scope = scope.where(vegetable: true) if current_flags.include?('vegetable')
+    scope
+  end
+
+  def browse_order
+    case current_sort
+    when 'name' then { scientific_name: :asc }
+    when 'complete' then { completion_ratio: :desc, wiki_score: :desc }
+    when 'recent' then { reviewed_at: :desc, wiki_score: :desc }
+    else { wiki_score: :desc }
+    end
+  end
+
+  # Searchkick indexes every attribute, so the browse filters translate
+  # directly. Name sort is not available on the analyzed field; search
+  # results stay relevance-ordered unless a numeric sort is asked for.
+  def search_where
+    where = {}
+    where[:rank] = current_rank if current_rank
+    where[:family_name] = current_family if current_family
+    where[:main_image_url] = { not: nil } if current_flags.include?('images')
+    where[:edible] = true if current_flags.include?('edible')
+    where[:vegetable] = true if current_flags.include?('vegetable')
+    where.presence
+  end
+
+  def search_order
+    case current_sort
+    when 'complete' then { completion_ratio: :desc }
+    when 'recent' then { reviewed_at: :desc }
+    end
+  end
+
+  # The most represented families, as browse chips. Refreshed daily; the
+  # grouped count is a sequential scan we don't want on every page view.
+  def family_chips
+    Rails.cache.fetch('explore/family_chips/v1', expires_in: 1.day) do
+      Species.where.not(family_name: nil)
+        .group(:family_name)
+        .order(Arel.sql('count_all DESC'))
+        .limit(FAMILY_CHIPS_COUNT)
+        .count
+        .keys
+    end
+  end
 
   # Use callbacks to share common setup or constraints between actions.
   def set_species

--- a/app/helpers/explore_helper.rb
+++ b/app/helpers/explore_helper.rb
@@ -1,0 +1,26 @@
+# Browse chrome for the explore pages: filter chips and rank labels.
+module ExploreHelper
+  RANK_LABELS = {
+    'species' => 'Species',
+    'ssp' => 'Subspecies',
+    'var' => 'Variety',
+    'form' => 'Form',
+    'hybrid' => 'Hybrid',
+    'subvar' => 'Subvariety'
+  }.freeze
+
+  def rank_chip_label(rank)
+    RANK_LABELS.fetch(rank, rank.humanize)
+  end
+
+  # A filter chip is a plain GET link that toggles one query parameter while
+  # keeping the others (search included) and resetting the page.
+  def explore_chip(label, key, value, active: false)
+    kept = request.query_parameters.except('page')
+    target = active ? kept.except(key.to_s) : kept.merge(key.to_s => value)
+    link_to label,
+            explore_path(target.symbolize_keys),
+            class: class_names('explore-chip', 'explore-chip--active' => active),
+            aria: { pressed: active.to_s }
+  end
+end

--- a/app/views/explore/species/_species_item.html.erb
+++ b/app/views/explore/species/_species_item.html.erb
@@ -1,20 +1,30 @@
-<%= link_to explore_species_path(species), class: 'species-grid-item' do %>
-  <aside><%= species_photo_tag(species, css_class: 'species-grid-item-photo') %></aside>
-  <main>
-    <h2 class="title is-5 scientific-name">
+<div class="explore-grid__cell">
+  <%= link_to explore_species_path(species), class: 'species-grid-item' do %>
+    <aside><%= species_photo_tag(species, css_class: 'species-grid-item-photo') %></aside>
+    <main>
+      <h2 class="title is-5 scientific-name">
 
-        <% if species.edible? %>
-          <span class="icon has-text-success is-small" title="Edible species">
-            <%= fa_icon('utensils', class: 'is-rounded is-primary') %>
-          </span>
-        <% end %>
-        <% if species.vegetable? %>
-          <span class="icon has-text-primary is-small" title="Vegetable species">
-            <%= fa_icon('carrot', class: 'is-rounded is-primary') %>
-          </span>
-        <% end %>
-      <%= species.scientific_name %>
-    </h2>
-    <p class="subtitle is-6"><%= species.common_name %></p>
-  </main>
-<% end %> 
+          <% if species.edible? %>
+            <span class="icon has-text-success is-small" title="Edible species">
+              <%= fa_icon('utensils', class: 'is-rounded is-primary') %>
+            </span>
+          <% end %>
+          <% if species.vegetable? %>
+            <span class="icon has-text-primary is-small" title="Vegetable species">
+              <%= fa_icon('carrot', class: 'is-rounded is-primary') %>
+            </span>
+          <% end %>
+        <%= species.scientific_name %>
+      </h2>
+      <p class="subtitle is-6"><%= species.common_name %></p>
+    </main>
+  <% end %>
+  <div class="explore-grid__meta">
+    <span class="explore-grid__family"><%= species.family_name %></span>
+    <% ratio = species.completion_ratio.to_i.clamp(0, 100) %>
+    <span class="explore-grid__completeness" title="<%= ratio %>% of trait fields filled">
+      <span class="explore-grid__completeness-track"><span class="explore-grid__completeness-fill" style="width: <%= ratio %>%"></span></span>
+      <span class="explore-grid__completeness-value"><%= ratio %>%</span>
+    </span>
+  </div>
+</div>

--- a/app/views/explore/species/index.html.erb
+++ b/app/views/explore/species/index.html.erb
@@ -1,52 +1,132 @@
-<div class="about-page home-page container">
-  <div class="columns">
-    <div class="column is-2"></div>
-    <div class="column is-8">
-      <section class="hero">
-        <div class="hero-body">
-          <div class="container">
-            <h1 class="title is-1">
-              <%= fa_icon('compass', class: 'has-text-primary') %>
-              Explore
-            </h1>
-            <h2 class="subtitle">
-              Browse and contribute to the Trefle botanical data.
-            </h2>
-            <p class="explore-corrections-link">
-              <%= link_to(explore_record_corrections_path(status: :pending)) do %>
-                <%= fa_icon('clipboard-list-check', class: 'has-text-primary') %> Review the corrections queue
-              <% end %>
-            </p>
-          </div>
-        </div>
-        <%= form_with(method: "get", local: true) do %>
-          <div class="control has-icons-left">
-            <input class="input is-large" name="search" value="<%= params[:search] %>" type="search" placeholder="Search">
-            <span class="icon is-medium is-left">
-              <%= fa_icon('search', class: 'has-text-primary') %>
-            </span>
-          </div>
-        <% end %>
-      </section>
+<%# Sections manage their own container and washes edge to edge, like the
+    home page (maquette Trefle Explore.dc.html). %>
+<% provide :full_bleed, '1' %>
+
+<section class="explore-header">
+  <div class="explore-header__inner">
+    <div class="explore-header__heading">
+      <span class="explore-header__icon"><%= fa_icon('compass') %></span>
+      <div>
+        <h1 class="explore-header__title">Explore</h1>
+        <p class="explore-header__intro">
+          Browse the indexed plants by scientific or common name, then refine
+          by rank, family or use. Each page can be completed by any account.
+        </p>
+      </div>
     </div>
-  </div>
 
-  <% if @collection %>
-    <div class="columns is-multiline">
+    <%= form_with(method: :get, local: true, class: 'explore-search') do %>
+      <div class="control has-icons-left">
+        <input class="input" name="search" value="<%= params[:search] %>" type="search"
+               placeholder="Search by scientific or common name" aria-label="Search plants">
+        <span class="icon is-left"><%= fa_icon('search', class: 'has-text-primary') %></span>
+      </div>
+      <%# Submitting a search keeps the active chips and sort, like the
+          chips keep the search terms. %>
+      <% request.query_parameters.except('search', 'page').each do |key, value| %>
+        <%= hidden_field_tag key, value %>
+      <% end %>
+    <% end %>
 
-      <% @collection.each do |species| %>
-        <div class="column is-3">
-          <%= render partial: 'explore/species/species_item', locals: {species: species} %>
+    <div class="explore-filters">
+      <div class="explore-filters__group">
+        <span class="explore-filters__label">Rank</span>
+        <div class="explore-filters__chips">
+          <% Species.ranks.each_key do |rank| %>
+            <%= explore_chip(rank_chip_label(rank), :rank, rank, active: current_rank == rank) %>
+          <% end %>
+        </div>
+      </div>
+      <% if @family_chips.any? %>
+        <div class="explore-filters__group">
+          <span class="explore-filters__label">Family</span>
+          <div class="explore-filters__chips">
+            <% @family_chips.each do |family| %>
+              <%= explore_chip(family, :family, family, active: current_family == family) %>
+            <% end %>
+          </div>
         </div>
       <% end %>
+      <div class="explore-filters__group">
+        <span class="explore-filters__label">Only</span>
+        <div class="explore-filters__chips">
+          <%= explore_chip('With images', :images, '1', active: current_flags.include?('images')) %>
+          <%= explore_chip('Edible', :edible, '1', active: current_flags.include?('edible')) %>
+          <%= explore_chip('Vegetable', :vegetable, '1', active: current_flags.include?('vegetable')) %>
+        </div>
+      </div>
     </div>
-    <div class="container">
-      <%== pagy_bulma_nav(@pagy) %>
-      <%== pagy_info(@pagy) %>
-    </div>
-  <% end %>
+  </div>
+</section>
 
-</div>
+<section class="explore-results">
+  <div class="explore-results__inner">
+    <div class="explore-results__header">
+      <p class="explore-results__count">
+        <% if @collection.any? %>
+          Showing <%= @pagy.from %>&ndash;<%= @pagy.to %> of <%= number_with_delimiter(@pagy.count) %> plants
+        <% else %>
+          No results
+        <% end %>
+      </p>
+      <%= form_with(method: :get, local: true, class: 'explore-sort') do %>
+        <% request.query_parameters.except('sort', 'page').each do |key, value| %>
+          <%= hidden_field_tag key, value %>
+        <% end %>
+        <label class="explore-sort__label" for="explore-sort-select">Sort</label>
+        <div class="select is-small">
+          <select id="explore-sort-select" name="sort" onchange="this.form.requestSubmit()">
+            <option value="" <%= 'selected' unless current_sort %>>Featured</option>
+            <option value="name" <%= 'selected' if current_sort == 'name' %>>Scientific name A&ndash;Z</option>
+            <option value="complete" <%= 'selected' if current_sort == 'complete' %>>Most complete</option>
+            <option value="recent" <%= 'selected' if current_sort == 'recent' %>>Recently corrected</option>
+          </select>
+        </div>
+        <noscript><button class="button is-small" type="submit">Apply</button></noscript>
+      <% end %>
+    </div>
+
+    <% if @collection.any? %>
+      <div class="explore-grid">
+        <% @collection.each do |species| %>
+          <%= render partial: 'explore/species/species_item', locals: { species: species } %>
+        <% end %>
+      </div>
+      <div class="explore-pagination">
+        <%== pagy_bulma_nav(@pagy) %>
+      </div>
+    <% else %>
+      <div class="explore-empty">
+        <p class="explore-empty__title">No plant matches this search.</p>
+        <p class="explore-empty__hint">
+          Check the spelling, try a genus name only, or
+          <%= link_to 'clear the filters', explore_path %>. A name we do not
+          index yet can be reported through
+          <%= link_to 'the corrections queue', explore_record_corrections_path %>.
+        </p>
+      </div>
+    <% end %>
+  </div>
+</section>
+
+<section class="explore-contribute">
+  <div class="explore-contribute__inner">
+    <div class="explore-contribute__heading">
+      <span class="explore-contribute__icon"><%= fa_icon('clipboard-list-check') %></span>
+      <h2 class="explore-contribute__title">Something missing or wrong?</h2>
+    </div>
+    <div>
+      <p class="explore-contribute__body">
+        Every species page lists the fields still unknown. Any account can
+        fill one in or correct a value; a reviewer checks it before it is
+        published. Corrections are attributed to their author.
+      </p>
+      <div class="explore-contribute__ctas">
+        <%= link_to 'See the corrections queue', explore_record_corrections_path(status: :pending), class: 'button' %>
+      </div>
+    </div>
+  </div>
+</section>
 
 <script>
   var temp_token = "<%= current_user&.token || @jwt.token %>";

--- a/db/migrate/20260907090000_add_explore_browse_indexes_to_species.rb
+++ b/db/migrate/20260907090000_add_explore_browse_indexes_to_species.rb
@@ -1,0 +1,9 @@
+# The explore browse page sorts by completion_ratio and reviewed_at and
+# filters by family_name; none of these had an index (~400k rows).
+class AddExploreBrowseIndexesToSpecies < ActiveRecord::Migration[8.0]
+  def change
+    add_index :species, :completion_ratio
+    add_index :species, :reviewed_at
+    add_index :species, :family_name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_09_05_160000) do
+ActiveRecord::Schema[8.0].define(version: 2026_09_07_090000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -455,7 +455,9 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_05_160000) do
     t.index ["author"], name: "index_species_on_author"
     t.index ["average_height_cm"], name: "index_species_on_average_height_cm"
     t.index ["common_name"], name: "index_species_on_common_name"
+    t.index ["completion_ratio"], name: "index_species_on_completion_ratio"
     t.index ["family_common_name"], name: "index_species_on_family_common_name"
+    t.index ["family_name"], name: "index_species_on_family_name"
     t.index ["flower_conspicuous"], name: "index_species_on_flower_conspicuous"
     t.index ["gbif_score"], name: "species_gbif_score_idx"
     t.index ["genus_id"], name: "species_genus_id_index"
@@ -472,6 +474,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_05_160000) do
     t.index ["planting_days_to_harvest"], name: "index_species_on_planting_days_to_harvest"
     t.index ["planting_row_spacing_cm"], name: "index_species_on_planting_row_spacing_cm"
     t.index ["planting_spread_cm"], name: "index_species_on_planting_spread_cm"
+    t.index ["reviewed_at"], name: "index_species_on_reviewed_at"
     t.index ["scientific_name"], name: "species_scientific_name_index", unique: true
     t.index ["slug"], name: "index_species_on_slug"
     t.index ["token"], name: "index_species_on_token"

--- a/spec/requests/web/explore_spec.rb
+++ b/spec/requests/web/explore_spec.rb
@@ -53,6 +53,89 @@ RSpec.describe 'Explore pages', type: :request do
     end
   end
 
+  describe 'GET /explore browse filters and sorts' do
+    def first_card_name
+      h2 = Nokogiri::HTML.fragment(response.body).at_css('.explore-grid__cell .species-grid-item h2')
+      h2.css('svg, style').remove # inline duotone icons carry a <style> block
+      h2.text.strip
+    end
+
+    it 'filters by rank' do
+      variety = Species.order(:id).first
+      variety.update_columns(rank: Species.ranks['var'])
+
+      get explore_path, params: { rank: 'var' }
+      expect(response.body).to include(variety.scientific_name)
+      expect(response.body).not_to include(Species.species_rank.order(wiki_score: :desc).first.scientific_name)
+    end
+
+    it 'ignores an unknown rank instead of erroring' do
+      get explore_path, params: { rank: 'cultivar' }
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'filters by family name' do
+      species = Species.order(:id).first
+      species.update_columns(family_name: 'Testaceae')
+
+      get explore_path, params: { family: 'Testaceae' }
+      expect(response.body).to include(species.scientific_name)
+      expect(response.body).to include('Showing 1&ndash;1 of 1 plants')
+    end
+
+    it 'keeps only species with an image when asked to' do
+      bare = Species.order(:id).first
+      bare.update_columns(main_image_url: nil)
+
+      get explore_path, params: { images: '1' }
+      expect(response.body).not_to include(bare.scientific_name)
+    end
+
+    it 'sorts by completion ratio' do
+      most_complete = Species.order(:id).first
+      most_complete.update_columns(completion_ratio: 99)
+
+      get explore_path, params: { sort: 'complete' }
+      expect(first_card_name).to eq(most_complete.scientific_name)
+    end
+
+    it 'sorts by scientific name' do
+      get explore_path, params: { sort: 'name' }
+      expect(first_card_name).to eq(Species.order(:scientific_name).first.scientific_name)
+    end
+
+    it 'marks the active filter chip and lets it toggle back off' do
+      get explore_path, params: { vegetable: '1' }
+      chip = Nokogiri::HTML.fragment(response.body).css('a.explore-chip--active').find {|a| a.text == 'Vegetable' }
+      expect(chip).not_to be_nil
+      expect(chip['href']).not_to include('vegetable=1')
+    end
+
+    it 'renders the empty state when nothing matches' do
+      get explore_path, params: { family: 'Nonexistaceae' }
+      expect(response.body).to include('No plant matches this search.')
+      expect(response.body).to include('clear the filters')
+    end
+
+    it 'shows each card with its family and completion percentage' do
+      species = Species.order(wiki_score: :desc).first
+      species.update_columns(completion_ratio: 42, family_name: 'Pinaceae')
+
+      get explore_path
+      card = Nokogiri::HTML.fragment(response.body).css('.explore-grid__cell').find do |cell|
+        cell.text.include?(species.scientific_name)
+      end
+      expect(card.at_css('.explore-grid__family').text).to eq('Pinaceae')
+      expect(card.at_css('.explore-grid__completeness-value').text).to eq('42%')
+    end
+
+    it 'links the corrections queue from the contribute band' do
+      get explore_path
+      expect(response.body).to include('Something missing or wrong?')
+      expect(response.body).to include(explore_record_corrections_path(status: :pending))
+    end
+  end
+
   describe 'GET /explore/species/:id' do
     it 'renders a species page by slug' do
       species = Species.friendly.find('abies-alba')


### PR DESCRIPTION
Implements `Trefle Explore.dc.html` from the design project (local reference: `.agents/design/home-2026/maquette-explore.html`), continuing the identity work from #307/#312/#314.

**Stacked on #315** (needs its `full_bleed` layout opt-out); the base retargets to master when #315 merges.

## What changes

- The explore index drops the old Bulma hero/columns for the maquette structure: full-bleed sections, compass + serif "Explore" heading, search, then a results section behind a hairline and a #f5f5f5 contribute band pointing at the corrections queue.
- **Filter chips**, all plain GET links that keep the other parameters (search included): Rank (the real enum — species, subspecies, variety, form, hybrid, subvariety; the mockup's "cultivar" has no equivalent), Family (top 7 families, daily-cached grouped count), Only (With images / Edible / Vegetable). Active chip = filled forest green, links back to off.
- **Sort select** (auto-submits, noscript Apply fallback): Featured (the existing wiki_score default), Scientific name A–Z, Most complete, Recently corrected.
- Cards keep their tested markup (lazy `img`, leaf placeholder) and gain a meta row: family in Roboto Mono + a 40×4px completion bar with the stored `completion_ratio`.
- Explicit empty state ("No plant matches this search." + clear-filters / corrections-queue links).
- Search mode: the same filters go through searchkick `where:` clauses (verified against the index — a stale dev document was the only false negative, reindexing it fixed the match); numeric sorts work there too, name sort stays browse-only (analyzed field).
- Migration: indexes on `completion_ratio`, `reviewed_at`, `family_name` (~400k rows, previously unindexed for these access paths).
- The genus pages reuse the card partial and pick up the meta row as-is.

## Verification

- Checked in Chrome against the maquette: header, chips (toggle on/off, combine with search — "Abies" + rank filter → 214 results on live data), sort (Most complete responds instantly on 489k rows thanks to the index), empty state, contribute band.
- RSpec: 1049 examples, 0 failures — including 10 new request specs covering each filter, both sorts, chip active/toggle state, the empty state, the card meta row and the contribute band. RuboCop: no offenses. `yarn build` clean.

Touches: app/controllers/explore/, app/helpers/, app/views/explore/species/, app/assets/javascripts/sections/_explore.scss, db/migrate/, spec/requests/web/