### PR TITLE
About: rebuild the page to the institutional maquette

### DIFF
--- a/app/assets/javascripts/application.scss
+++ b/app/assets/javascripts/application.scss
@@ -12,6 +12,7 @@
 
 @import 'sections/home';
 @import 'sections/explore';
+@import 'sections/about';
 @import 'sections/navbar';
 @import 'sections/footer';
 
@@ -203,4 +204,11 @@ button:focus-visible,
 .fa-icon.fa-3x {
   width: 3em;
   height: 3em;
+}
+// Anchor navigation (about sections, home #data) glides instead of jumping,
+// unless the user asked for reduced motion.
+@media (prefers-reduced-motion: no-preference) {
+  html {
+    scroll-behavior: smooth;
+  }
 }

--- a/app/assets/javascripts/sections/_about.scss
+++ b/app/assets/javascripts/sections/_about.scss
@@ -1,0 +1,257 @@
+@import "variables";
+
+// About page, rebuilt from Trefle About.dc.html
+// (.agents/design/home-2026/maquette-about.html): header + anchor nav, then
+// six stacked sections; the targeted section grows a forest-green left rail.
+
+.about {
+  &__header {
+    box-sizing: border-box;
+    margin: 0 auto;
+    max-width: $layout-max-width;
+    padding: 4rem 1.5rem 0;
+  }
+
+  &__heading {
+    align-items: flex-start;
+    display: flex;
+    gap: 0.75rem;
+  }
+
+  &__heading-icon {
+    color: $forest-green;
+    display: inline-flex;
+    font-size: 2rem;
+    line-height: 1;
+    margin-top: 0.5rem;
+  }
+
+  &__title {
+    color: #0a0a0a;
+    font-family: $family-serif;
+    font-size: clamp(2.5rem, 5vw, 3.5rem);
+    font-weight: 500;
+    line-height: 1.05;
+    margin: 0;
+  }
+
+  &__lead {
+    font-size: 1.125rem;
+    margin: 0.75rem 0 0;
+    text-wrap: pretty;
+  }
+
+  &__nav {
+    border-bottom: 1px solid #dbdbdb;
+    border-top: 1px solid #dbdbdb;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0 1.75rem;
+    margin-top: 2.5rem;
+
+    a {
+      color: #363636;
+      font-size: 0.875rem;
+      padding: 0.75rem 0;
+      white-space: nowrap;
+
+      &:hover,
+      &:focus {
+        color: $forest-green;
+        text-decoration: none;
+      }
+    }
+  }
+
+  &__body {
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    margin: 0 auto;
+    max-width: $layout-max-width;
+    min-width: 0;
+    padding: 1rem 1.5rem 4rem;
+  }
+}
+
+.about-section {
+  border-top: 1px solid #dbdbdb;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-left: -1rem;
+  margin-top: 3.5rem;
+  padding-left: 1rem;
+  padding-top: 3rem;
+
+  // The anchored section is marked by a left rail, like the species page
+  // sections (--border-accent in the design tokens).
+  &:target {
+    box-shadow: -2px 0 0 $forest-green;
+  }
+
+  &--first {
+    border-top: 0;
+    margin-top: 0;
+    padding-top: 0;
+  }
+
+  p {
+    margin: 0;
+    text-wrap: pretty;
+  }
+
+  &__heading {
+    align-items: center;
+    display: flex;
+    gap: 0.6rem;
+  }
+
+  &__icon {
+    color: $forest-green;
+    display: inline-flex;
+    font-size: 1.5rem;
+    line-height: 1;
+  }
+
+  &__title {
+    color: #0a0a0a;
+    font-family: $family-serif;
+    font-size: 2.25rem;
+    font-weight: 500;
+    line-height: 1.1;
+    margin: 0;
+  }
+
+  &__more {
+    font-size: 0.9375rem;
+  }
+}
+
+.about-sources {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+
+  &__caption {
+    color: #7a7a7a;
+    font-size: 0.875rem;
+  }
+
+  &__logos {
+    align-items: center;
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(90px, 1fr));
+
+    img {
+      display: block;
+      filter: grayscale(1);
+      max-height: 44px;
+      object-fit: contain;
+      transition: filter 150ms;
+      width: 100%;
+
+      &:hover {
+        filter: grayscale(0);
+      }
+    }
+  }
+}
+
+.about-tiles {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  margin-top: 0.5rem;
+}
+
+.about-tile {
+  border: 1px solid #dbdbdb;
+  border-radius: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 1.25rem;
+
+  &__eyebrow {
+    color: #7a7a7a;
+    font-family: $family-monospace;
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  &__value {
+    color: #0a0a0a;
+    font-family: $family-monospace;
+    font-size: 1.5rem;
+  }
+
+  &__note {
+    font-size: 0.875rem;
+  }
+}
+
+.about-citation {
+  background: #f5f5f5;
+  border: 1px solid #dbdbdb;
+  border-radius: 4px;
+  color: #363636;
+  font-family: $family-monospace;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  margin: 0;
+  padding: 0.875rem 1rem;
+  white-space: pre-wrap;
+}
+
+.about-contacts {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  margin-top: 0.5rem;
+}
+
+.about-contact {
+  border-top: 1px solid #dbdbdb;
+  color: #363636;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding-top: 1rem;
+
+  &:hover,
+  &:focus {
+    color: $forest-green;
+    text-decoration: none;
+  }
+
+  &__eyebrow {
+    color: #7a7a7a;
+    font-family: $family-monospace;
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  &__value {
+    align-items: center;
+    color: #0a0a0a;
+    display: inline-flex;
+    font-family: $family-monospace;
+    gap: 0.4rem;
+  }
+
+  &__brand {
+    display: inline-flex;
+
+    &--discord {
+      color: #7289da;
+    }
+
+    &--github {
+      color: #242a2f;
+    }
+  }
+}

--- a/app/assets/javascripts/sections/_home.scss
+++ b/app/assets/javascripts/sections/_home.scss
@@ -398,6 +398,16 @@
   grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
   margin: 2.5rem 0 0;
 
+  // The about page reuses the tiles inside a section, slightly smaller.
+  &--compact {
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    margin: 0.5rem 0 0;
+
+    .home-stat-tiles__tile dt {
+      font-size: 1.5rem;
+    }
+  }
+
   &__tile {
     display: flex;
     flex-direction: column;

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -21,6 +21,23 @@ class HomeController < ApplicationController
     @page_title       = 'About'
     @page_description = 'Trefle is a botanical API and data source.'
     @page_keywords    = 'API, Botanical, Plants, Species, Data'
+    @team_stats       = about_team_stats
+  end
+
+  private
+
+  # Real numbers for the about page team tiles: admins maintain the platform,
+  # reviewers have accepted at least one correction, contributors submitted
+  # one this year. Cached: three aggregates nobody needs fresher than daily.
+  def about_team_stats
+    Rails.cache.fetch('about/team_stats/v1', expires_in: 1.day) do
+      {
+        core: User.where(admin: true).count,
+        reviewers: RecordCorrection.where.not(accepted_by: nil).distinct.count(:accepted_by),
+        contributors: RecordCorrection.where(created_at: Time.zone.now.beginning_of_year..)
+          .where.not(user_id: nil).distinct.count(:user_id)
+      }
+    end
   end
 
 end

--- a/app/views/home/about.html.erb
+++ b/app/views/home/about.html.erb
@@ -1,139 +1,164 @@
-<div class="about-page home-page container is-fluid">
+<%# Rebuilt from Trefle About.dc.html
+    (.agents/design/home-2026/maquette-about.html): header + anchor nav, six
+    sections with a forest-green :target rail, factual team numbers. %>
+<% provide :full_bleed, '1' %>
 
-  <div class="columns">
-    <div class="column is-2"></div>
-    <div class="column is-10">
-      <section class="hero">
-        <div class="hero-body">
-          <div class="container">
-            <h1 class="title is-1">
-              <%= fa_icon('seedling', class: 'has-text-primary') %>
-
-              About
-            </h1>
-            <h2 class="subtitle">
-              General informations, privacy and contacts.
-            </h2>
-          </div>
-        </div>
-      </section>
+<div class="about">
+  <header class="about__header">
+    <div class="about__heading">
+      <span class="about__heading-icon"><%= fa_icon('clipboard-user') %></span>
+      <div>
+        <h1 class="about__title">About Trefle</h1>
+        <p class="about__lead">
+          Trefle is an open botanical data source and REST API, maintained by a
+          small volunteer team and backed by <a href="https://mashum.org">Mashum</a>.
+          It indexes about one million plants and is free for everyone.
+        </p>
+      </div>
     </div>
+    <nav class="about__nav" aria-label="About sections">
+      <a href="#sources">Data sources</a>
+      <a href="#team">The team</a>
+      <a href="#pricing">Pricing &amp; limits</a>
+      <a href="#licence">Licence &amp; citation</a>
+      <a href="#privacy">Privacy</a>
+      <a href="#contact">Contact</a>
+    </nav>
+  </header>
+
+  <div class="about__body">
+    <section id="sources" class="about-section about-section--first">
+      <div class="about-section__heading">
+        <span class="about-section__icon"><%= fa_icon('database') %></span>
+        <h2 class="about-section__title">Data sources</h2>
+      </div>
+      <p>
+        Records are gathered from institutional databases, reconciled on the
+        accepted scientific name, and completed by hand by contributors. Each
+        species page states which sources it draws from and links back to them.
+      </p>
+      <div class="about-sources">
+        <p class="about-sources__caption">Data is gathered from</p>
+        <div class="about-sources__logos">
+          <%= image_tag asset_path('medias/usda.svg'), alt: 'USDA' %>
+          <%= image_tag asset_path('medias/kew.svg'), alt: 'Kew Royal Botanic Gardens' %>
+          <%= image_tag asset_path('medias/ipni.png'), alt: 'IPNI' %>
+          <%= image_tag asset_path('medias/tropicos.gif'), alt: 'Tropicos' %>
+          <%= image_tag asset_path('medias/tela-botanica.png'), alt: 'Tela Botanica' %>
+          <%= image_tag asset_path('medias/wikimedia.png'), alt: 'Wikimedia' %>
+          <%= image_tag asset_path('medias/muhitnat.png'), alt: 'MuhitNat' %>
+        </div>
+        <p class="about-sources__caption">and completed by hand by contributors around the world.</p>
+      </div>
+    </section>
+
+    <section id="team" class="about-section">
+      <div class="about-section__heading">
+        <span class="about-section__icon"><%= fa_icon('hand-heart') %></span>
+        <h2 class="about-section__title">The team</h2>
+      </div>
+      <p>
+        Trefle started in 2016 and is run by volunteers: developers, data
+        reviewers and contributors who correct species pages. Hosting and
+        research are covered by donations and by Mashum association.
+      </p>
+      <dl class="home-stat-tiles home-stat-tiles--compact">
+        <div class="home-stat-tiles__tile">
+          <dt><%= number_with_delimiter(@team_stats[:core]) %></dt>
+          <dd>core maintainers</dd>
+        </div>
+        <div class="home-stat-tiles__tile">
+          <dt><%= number_with_delimiter(@team_stats[:reviewers]) %></dt>
+          <dd>data reviewers</dd>
+        </div>
+        <div class="home-stat-tiles__tile">
+          <dt><%= number_with_delimiter(@team_stats[:contributors]) %></dt>
+          <dd>contributors this year</dd>
+        </div>
+      </dl>
+      <p class="about-section__more">
+        Want to help? See <%= link_to 'how to join the team', root_path(anchor: 'volunteer') %>.
+      </p>
+    </section>
+
+    <section id="pricing" class="about-section">
+      <div class="about-section__heading">
+        <span class="about-section__icon"><%= fa_icon('server') %></span>
+        <h2 class="about-section__title">Pricing and limits</h2>
+      </div>
+      <p>
+        Trefle is free for all, and always will be. Server maintenance is
+        expensive, so requests are rate-limited.
+      </p>
+      <div class="about-tiles">
+        <div class="about-tile">
+          <span class="about-tile__eyebrow">Free account</span>
+          <span class="about-tile__value">60 req/min</span>
+          <span class="about-tile__note">Full dataset, all endpoints.</span>
+        </div>
+        <div class="about-tile">
+          <span class="about-tile__eyebrow">GitHub sponsor</span>
+          <span class="about-tile__value">600 req/min</span>
+          <span class="about-tile__note">Or more, if needed. <%= link_to 'Become a sponsor', donate_path %>.</span>
+        </div>
+        <div class="about-tile">
+          <span class="about-tile__eyebrow">Institutions</span>
+          <span class="about-tile__value">Bulk export</span>
+          <span class="about-tile__note">Arranged case by case. <a href="#contact">Contact us</a>.</span>
+        </div>
+      </div>
+    </section>
+
+    <section id="licence" class="about-section">
+      <div class="about-section__heading">
+        <span class="about-section__icon"><%= fa_icon('book') %></span>
+        <h2 class="about-section__title">Licence and citation</h2>
+      </div>
+      <p>
+        The API and platform code are open source. Data keeps the licence of
+        its source; corrections made on Trefle are published under an open
+        licence. Images carry their own attribution.
+      </p>
+      <p class="about-section__more">To cite Trefle in a publication:</p>
+      <pre class="about-citation">Trefle (<%= Date.current.year %>). Trefle: a global plants API. https://trefle.io &mdash; accessed <%= Date.current.iso8601 %>.</pre>
+    </section>
+
+    <section id="privacy" class="about-section">
+      <div class="about-section__heading">
+        <span class="about-section__icon"><%= fa_icon('key') %></span>
+        <h2 class="about-section__title">(very short) privacy policy</h2>
+      </div>
+      <p>
+        Trefle.io take your privacy seriously and will take all measures to
+        protect your personal information. We store your e-mail, your API token
+        and your corrections. We will not sell or redistribute your information
+        to anyone. No third-party tracking.
+      </p>
+    </section>
+
+    <section id="contact" class="about-section">
+      <div class="about-section__heading">
+        <span class="about-section__icon"><%= fa_icon('mailbox') %></span>
+        <h2 class="about-section__title">Contact</h2>
+      </div>
+      <p>
+        Questions, partnerships, datasets to integrate, educational projects
+        &mdash; write to us. We reply to every message, usually within a few days.
+      </p>
+      <div class="about-contacts">
+        <a href="mailto:hello@trefle.io" class="about-contact">
+          <span class="about-contact__eyebrow">E-mail</span>
+          <span class="about-contact__value">hello@trefle.io</span>
+        </a>
+        <a href="https://discord.gg/fuamwgk" class="about-contact">
+          <span class="about-contact__eyebrow">Discord</span>
+          <span class="about-contact__value"><span class="about-contact__brand about-contact__brand--discord"><%= fa_icon('discord', style: :brands) %></span>Join the server</span>
+        </a>
+        <a href="https://github.com/treflehq/trefle-api" class="about-contact">
+          <span class="about-contact__eyebrow">GitHub</span>
+          <span class="about-contact__value"><span class="about-contact__brand about-contact__brand--github"><%= fa_icon('github', style: :brands) %></span>treflehq/trefle-api</span>
+        </a>
+      </div>
+    </section>
   </div>
-
-  <div class="columns">
-    <div class="column is-2">
-      <br>
-      <br>
-      <aside class="menu">
-        <ul class="menu-list">
-          <li><a href="#sources">Data sources</a></li>
-          <li><a href="#privacy">Privacy</a></li>
-          <li><a href="#pricing">Pricing</a></li>
-          <li><a href="#beta-disclaimer">Beta stage</a></li>
-          <li><a href="#contact">Contact</a></li>
-        </ul>
-      </aside>
-    </div>
-
-    <div class="column is-10">
-
-      <section class="section logo-section" id="about">
-        <h4 class="title is-4">
-          We deliver all plants informations under an accessible API.
-        </h4>
-      </section>
-
-      <section class="section content logo-section" id="sources">
-        <p class="has-text-centered has-text-grey">Our data is gathered with love from</p>
-        <br>
-        <div class="has-text-centered">
-          <img style="display: inline-block; max-height: 80px; max-width: 100px; padding: 10px; margin: auto" src="<%= asset_path("medias/usda.svg") %>" alt="">
-          <img style="display: inline-block; max-height: 80px; max-width: 100px; padding: 10px; margin: auto" src="<%= asset_path("medias/tela-botanica.png") %>" alt="">
-          <img style="display: inline-block; max-height: 80px; max-width: 100px; padding: 10px; margin: auto" class="spadded" src="<%= asset_path("medias/tropicos.gif") %>" alt="">
-          <img style="display: inline-block; max-height: 80px; max-width: 100px; padding: 10px; margin: auto" src="<%= asset_path("medias/ipni.png") %>" alt="">
-          <img style="display: inline-block; max-height: 80px; max-width: 100px; padding: 10px; margin: auto" class="all-spadded" src="<%= asset_path("medias/kew.svg") %>" alt="">
-          <img style="display: inline-block; max-height: 80px; max-width: 100px; padding: 10px; margin: auto" src="<%= asset_path("medias/wikimedia.png") %>" alt="">
-          <img style="display: inline-block; max-height: 80px; max-width: 100px; padding: 10px; margin: auto" src="<%= asset_path("medias/muhitnat.png") %>" alt="">  
-        </div>
-        <p class="has-text-centered has-text-grey">& manually from people all around the world</p>
-      </section>
-
-      <!-- <hr> -->
-      <section class="section content" id="privacy">
-        <h1 class="title is-4 ">
-          <%= fa_icon('user-secret', class: 'has-text-success') %> (very short) privacy policy
-        </h1>
-        <p>Trefle.io take your privacy seriously and will take all measures to protect your personal information.</p>
-        <p>Any personal information received will only be used to fulfill your order, and may be used for anonymized internal analytical purposes.</p>
-        <p>We will not sell or redistribute your information to anyone.</p>
-      </section>
-
-      <section class="section content" id="pricing">
-        <h1 class="title is-4 ">
-          <%= fa_icon('money-bill-wave', class: 'has-text-success') %> Pricing
-        </h1>
-        <p><b>Trefle is free for all</b>, and always will be.</p>
-        <p>However, server maintenance is expensive, so we impose a limit of 60 requests per minute. If you have higher needs, or just want to help us keep Trefle up and running, you can <a href="https://github.com/sponsors/treflehq" target="_blank">sponsor us on GitHub</a>.</p>
-      </section>
-
-      <section class="section content" id="support">
-        <h1 class="title is-4 ">
-          <%= fa_icon('hand-heart', class: 'has-text-success') %> Need more requests ?
-        </h1>
-        <p><b>Sponsors have an extended request limit of 600 requests/minute.</b></p>
-        <p>Read <a href="<%= donate_path %>">how to become a sponsor</a>.</p>
-      </section>
-
-
-      <section class="section content" id="beta-disclaimer">
-        <h1 class="title is-4 ">
-          <%= fa_icon('flask-potion', class: 'has-text-success') %>
-          Beta disclaimer
-        </h1>
-        <p>Trefle is actually in beta stage, which implies that bugs and issues may still remain undiscovered until this phase of testing is complete.</p>
-        <p>The beta stage also means that the data may be corrupted, is not 100% validated or complete, and is subject to change.</p>
-        <p>Finally, services may have downtime and the API schemas and calls are subject to change.</p>
-      </section>
-      <hr>
-      <section class="section content" id="contact">
-        <h1 class="title is-4 ">
-          <%= fa_icon('mailbox', class: 'has-text-success') %>
-
-          Contact us
-        </h1>
-        <p>If you have questions, advices, partnerships or if you just want to say hello, please contact us, we'll be our pleasure to reply!</p>
-
-      </section>
-      <section class="section content" id="contact">
-        <div class="columns">
-          <div class="column is-4">
-            <a href="mailto:hello@trefle.io">
-              <h2 class="title is-5 has-text-centered">Send us a mail</h2>
-              <p class="has-text-centered">hello@trefle.io</p>
-            </a>
-          </div>
-          <div class="column is-4">
-            <a title="Join us on Discord" href="https://discord.gg/fuamwgk" target="_blank">
-              <h2 class="title is-5 has-text-centered">Join us on Discord</h2>
-              <p class="has-text-centered">
-                <span class="icon" style="color: #7289da;">
-                  <%= fa_icon('discord', style: :brands, class: 'fa-3x fa-lg') %>
-                </span>
-              </p>
-            </a>
-          </div>
-          <div class="column is-4">
-            <a title="Follow us on Twitter" href="https://twitter.com/trefle_api" target="_blank">
-              <h2 class="title is-5 has-text-centered">Follow us on Twitter</h2>
-              <p class="has-text-centered">
-                <span class="icon" style="color: #55acee;">
-                  <%= fa_icon('twitter', style: :brands, class: 'fa-3x fa-lg') %>
-                </span>
-              </p>
-            </a>
-          </div>
-        </div>
-      </section>
-
-    </div>
-  </div>
+</div>

--- a/app/views/home/about.html.erb
+++ b/app/views/home/about.html.erb
@@ -115,12 +115,21 @@
         <h2 class="about-section__title">Licence and citation</h2>
       </div>
       <p>
-        The API and platform code are open source. Data keeps the licence of
-        its source; corrections made on Trefle are published under an open
-        licence. Images carry their own attribution.
+        The API and platform code are open source under
+        <a href="https://www.gnu.org/licenses/agpl-3.0.html">AGPL-3.0</a>.
+        The Trefle database &mdash; the compilation, its structure and the
+        community corrections &mdash; is published under
+        <a href="https://creativecommons.org/licenses/by/4.0/">CC-BY 4.0</a>.
+        Individual records aggregate facts from upstream sources, and each
+        upstream source keeps its own licence. Images carry their own
+        attribution.
+      </p>
+      <p>
+        Using Trefle in an app? Display &ldquo;Data: Trefle.io (CC-BY
+        4.0)&rdquo; with a link back to trefle.io.
       </p>
       <p class="about-section__more">To cite Trefle in a publication:</p>
-      <pre class="about-citation">Trefle (<%= Date.current.year %>). Trefle: a global plants API. https://trefle.io &mdash; accessed <%= Date.current.iso8601 %>.</pre>
+      <pre class="about-citation">Trefle (<%= Date.current.year %>). Trefle: a global plants API. https://trefle.io &mdash; data licensed CC-BY 4.0, accessed <%= Date.current.iso8601 %>.</pre>
     </section>
 
     <section id="privacy" class="about-section">

--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -12,8 +12,10 @@ RSpec.feature 'Home page', type: :feature do
 
   scenario 'User visits the about page' do
     visit '/about'
-    expect(page).to have_text('We deliver all plants informations')
-    expect(page).to have_text('Contact us')
+    expect(page).to have_text('About Trefle')
+    expect(page).to have_text('Trefle is free for all, and always will be.')
+    expect(page).to have_text('Contact')
+    expect(page).to have_text('hello@trefle.io')
     expect(page).to have_text('Sign in')
     expect(page).to have_text('Documentation')
   end

--- a/spec/requests/web/home_spec.rb
+++ b/spec/requests/web/home_spec.rb
@@ -28,6 +28,23 @@ RSpec.describe 'Public website pages', type: :request do
       get about_path
       expect(response).to have_http_status(:ok)
     end
+
+    it 'shows the computed team numbers, the rate-limit tiles and the citation' do
+      get about_path
+      expect(response.body).to include('core maintainers')
+      expect(response.body).to include('60 req/min')
+      expect(response.body).to include('600 req/min')
+      expect(response.body).to include("accessed #{Date.current.iso8601}")
+    end
+
+    it 'links every section from the anchor nav' do
+      get about_path
+      nav = Nokogiri::HTML.fragment(response.body).at_css('.about__nav')
+      anchors = nav.css('a').map {|a| a['href'] }
+      expect(anchors).to eq(%w[#sources #team #pricing #licence #privacy #contact])
+      body = Nokogiri::HTML.fragment(response.body)
+      anchors.each {|anchor| expect(body.at_css(anchor)).not_to be_nil }
+    end
   end
 
   describe 'GET /donate' do


### PR DESCRIPTION
Implements `Trefle About.dc.html` from the design project (local reference: `.agents/design/home-2026/maquette-about.html`), continuing the identity work from #314/#315/#316.

**Stacked on #316** (explore), itself stacked on #315 (the `full_bleed` layout opt-out); bases retarget automatically as they merge.

## What changes

- The about page drops the old Bulma hero + sticky side menu for the maquette structure: serif "About Trefle" heading + factual lead (Mashum link), an anchor nav between hairlines, then six stacked sections separated by hairlines.
- **Sections**: Data sources (7-logo grayscale grid with real alt texts), The team, Pricing and limits (three bordered tiles: 60 req/min free, 600 for sponsors, bulk export for institutions), Licence and citation (a ready-to-copy `<pre>` citation dated per request — the page has no fragment cache), the (very short) privacy policy, Contact (e-mail / Discord / GitHub tiles with brand-colored icons).
- **The team tiles carry computed numbers** instead of copy that would drift: admin count, distinct correction reviewers (`accepted_by`), distinct contributors this year — cached for a day.
- `section:target` shows the maquette's 2px forest-green left rail; anchor navigation scrolls smoothly behind a `prefers-reduced-motion` guard.
- Dropped: the "Beta stage" section (that honesty now lives in the home Data section) and the Twitter contact tile.
- The home stat tiles gain a `--compact` modifier reused here.

## Verification

- Checked in Chrome against the maquette: header + anchor nav, all six sections, the `:target` rail on `/about#pricing`, brand icons, footer.
- RSpec: 1051 examples, 0 failures — including new request specs for the team numbers, rate-limit tiles, per-request citation date, and an anchor-nav integrity check (every nav href resolves to a section id). Feature spec updated to the new copy. RuboCop: no offenses. `yarn build` clean.

Touches: app/controllers/home_controller.rb, app/views/home/about.html.erb, app/assets/javascripts/, spec/