### PR TITLE
Home design pass: aligned headings, no step numbers, wrapped commands, AA muted grey

### DIFF
--- a/app/assets/javascripts/application.scss
+++ b/app/assets/javascripts/application.scss
@@ -139,7 +139,7 @@ span.token.number {
 
 .auth-divider {
   align-items: center;
-  color: #7a7a7a;
+  color: $text-muted;
   display: flex;
   font-size: 0.85rem;
   margin: 1.5rem 0;
@@ -160,7 +160,7 @@ span.token.number {
 
 .auth-links {
   align-items: center;
-  color: #7a7a7a;
+  color: $text-muted;
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem 1rem;

--- a/app/assets/javascripts/home/codesandbox.js
+++ b/app/assets/javascripts/home/codesandbox.js
@@ -104,7 +104,15 @@ const CodeSandbox = (props) => {
             <span className="home-terminal__dot home-terminal__dot--minimize"></span>
             <span className="home-terminal__dot home-terminal__dot--zoom"></span>
           </div>
-          <SyntaxHighlighter language="http" style={monokai} customStyle={TERMINAL_CODE_STYLE}>
+          <SyntaxHighlighter
+            language="http"
+            style={monokai}
+            customStyle={{ ...TERMINAL_CODE_STYLE, wordBreak: 'break-all' }}
+            // Wrap the command instead of growing a horizontal scrollbar under
+            // the terminal bar (wrapLongLines is the only supported way: the
+            // library pins white-space inline on the <code> tag).
+            wrapLongLines
+          >
             {`$ ${cmd}`}
           </SyntaxHighlighter>
           <SyntaxHighlighter language="json" style={monokai} customStyle={{ ...TERMINAL_CODE_STYLE, maxHeight: '260px' }}>

--- a/app/assets/javascripts/sections/_about.scss
+++ b/app/assets/javascripts/sections/_about.scss
@@ -134,7 +134,7 @@
   gap: 0.75rem;
 
   &__caption {
-    color: #7a7a7a;
+    color: $text-muted;
     font-size: 0.875rem;
   }
 
@@ -175,7 +175,7 @@
   padding: 1.25rem;
 
   &__eyebrow {
-    color: #7a7a7a;
+    color: $text-muted;
     font-family: $family-monospace;
     font-size: 0.75rem;
     letter-spacing: 0.08em;
@@ -228,7 +228,7 @@
   }
 
   &__eyebrow {
-    color: #7a7a7a;
+    color: $text-muted;
     font-family: $family-monospace;
     font-size: 0.75rem;
     letter-spacing: 0.08em;

--- a/app/assets/javascripts/sections/_explore.scss
+++ b/app/assets/javascripts/sections/_explore.scss
@@ -127,7 +127,7 @@
     }
 
     p {
-      color: #6f6f6f
+      color: $text-muted
     }
   }
 
@@ -135,7 +135,7 @@
     display: flex;
     justify-content: flex-start;
     align-items: center;
-    color: #6f6f6f;
+    color: $text-muted;
 
     .footer-item {
       min-width: 100px;
@@ -187,7 +187,7 @@
     }
 
     p {
-      color: #6f6f6f
+      color: $text-muted
     }
   }
 }
@@ -594,7 +594,7 @@
   }
 
   &__intro {
-    color: #7a7a7a;
+    color: $text-muted;
     margin: 0.5rem 0 0;
     max-width: 60ch;
     text-wrap: pretty;
@@ -620,7 +620,7 @@
   }
 
   &__label {
-    color: #7a7a7a;
+    color: $text-muted;
     font-family: $family-monospace;
     font-size: 0.6875rem;
     letter-spacing: 0.08em;
@@ -695,7 +695,7 @@
   gap: 0.5rem;
 
   &__label {
-    color: #7a7a7a;
+    color: $text-muted;
     font-size: 0.875rem;
   }
 }
@@ -714,7 +714,7 @@
 
   &__meta {
     align-items: center;
-    color: #7a7a7a;
+    color: $text-muted;
     display: flex;
     font-size: 0.75rem;
     gap: 0.5rem;
@@ -774,7 +774,7 @@
   }
 
   &__hint {
-    color: #7a7a7a;
+    color: $text-muted;
     margin: 0.5rem 0 0;
     text-wrap: pretty;
   }

--- a/app/assets/javascripts/sections/_home.scss
+++ b/app/assets/javascripts/sections/_home.scss
@@ -74,7 +74,7 @@
     }
 
     p {
-      color: #6f6f6f
+      color: $text-muted
     }
   }
 }
@@ -141,7 +141,7 @@
 }
 
 .home-muted-note {
-  color: #7a7a7a;
+  color: $text-muted;
 }
 
 // Hero -----------------------------------------------------------------
@@ -224,7 +224,7 @@
 }
 
 .home-start-here__eyebrow {
-  color: #7a7a7a;
+  color: $text-muted;
   font-family: $family-monospace;
   font-size: 0.75rem;
   letter-spacing: 0.08em;
@@ -280,6 +280,14 @@
   display: flex;
   gap: 0.75rem;
 
+  // Hang the icon in the left margin so the title text sits on the same
+  // vertical axis as the section body below it. Only when the viewport has
+  // room beyond the container for the 1.75rem icon + 0.75rem gap; narrower
+  // screens keep the inline icon.
+  @media (min-width: 1080px) {
+    margin-left: -2.5rem;
+  }
+
   &__icon {
     color: $forest-green;
     display: inline-flex;
@@ -298,7 +306,7 @@
   }
 
   &__intro {
-    color: #7a7a7a;
+    color: $text-muted;
     margin: 0.5rem 0 0;
     max-width: 60ch;
     text-wrap: pretty;
@@ -358,7 +366,7 @@
 
   &__caption,
   &__footnote {
-    color: #7a7a7a;
+    color: $text-muted;
   }
 
   &__caption {
@@ -421,7 +429,7 @@
     }
 
     dd {
-      color: #7a7a7a;
+      color: $text-muted;
       font-size: 0.875rem;
       margin: 0;
     }
@@ -457,7 +465,7 @@
   }
 
   &__axis {
-    color: #7a7a7a;
+    color: $text-muted;
     display: flex;
     font-family: $family-monospace;
     font-size: 0.75rem;
@@ -466,7 +474,7 @@
   }
 
   &__empty {
-    color: #7a7a7a;
+    color: $text-muted;
     font-size: 0.875rem;
     margin: 0.75rem 0 0;
   }
@@ -504,7 +512,7 @@
   }
 
   &__meta {
-    color: #7a7a7a;
+    color: $text-muted;
     font-size: 0.75rem;
     max-width: 13rem;
     overflow: hidden;
@@ -564,11 +572,6 @@
     gap: 0.5rem;
     padding-top: 1rem;
   }
-
-  &__index {
-    color: #7a7a7a;
-    font-size: 0.75rem;
-  }
 }
 
 .home-code-sample {
@@ -579,11 +582,9 @@
   font-size: 0.8125rem;
   line-height: 1.5;
   margin: 0.25rem 0 0;
-  overflow-x: auto;
+  overflow-wrap: anywhere;
   padding: 0.75rem 1rem;
-  scrollbar-color: #7a7a7a transparent;
-  scrollbar-width: thin;
-  white-space: pre;
+  white-space: pre-wrap;
 }
 
 // Research and education: bordered cards ----------------------------------
@@ -682,7 +683,7 @@
   }
 
   &__label {
-    color: #7a7a7a;
+    color: $text-muted;
     font-family: $family-monospace;
     font-size: 0.75rem;
     letter-spacing: 0.08em;
@@ -716,7 +717,7 @@
   // The command line and JSON block are react-syntax-highlighter <pre>s;
   // keep their overflow scrollbars discreet inside the dark terminal.
   pre {
-    scrollbar-color: #7a7a7a #363636;
+    scrollbar-color: $text-muted #363636;
     scrollbar-width: thin;
   }
 

--- a/app/assets/javascripts/sections/_variables.scss
+++ b/app/assets/javascripts/sections/_variables.scss
@@ -26,6 +26,12 @@ $title-color: #0a0a0a;
 $body-color: #363636;
 $body-line-height: 1.6;
 
+// Muted/secondary text. The design system's original muted grey (#7a7a7a)
+// measures 4.3:1 on white — under WCAG AA's 4.5:1 for normal text — so the
+// working value is nudged to 5.1:1 while keeping the muted look. Use this
+// variable, never a literal grey, for secondary copy.
+$text-muted: #6e6e6e;
+
 // The h1-h6/body/small scale, defined once instead of the ad-hoc px/em values
 // that used to be sprinkled across sections/*.scss (see #234). Values mirror
 // Bulma's own $size-1.."$size-7", but are declared independently since these

--- a/app/views/home/_developers.html.erb
+++ b/app/views/home/_developers.html.erb
@@ -7,17 +7,14 @@
 
     <ol class="home-steps">
       <li class="home-steps__step">
-        <span class="home-mono home-steps__index">01</span>
         <h3 class="home-subheading">Create an account, get a token</h3>
         <p>Your token allows you to make queries on the API. Keep it private.</p>
       </li>
       <li class="home-steps__step">
-        <span class="home-mono home-steps__index">02</span>
         <h3 class="home-subheading">Make your first request</h3>
         <pre class="home-code-sample">curl "https://trefle.io/api/v1/plants?token=YOUR_TOKEN"</pre>
       </li>
       <li class="home-steps__step">
-        <span class="home-mono home-steps__index">03</span>
         <h3 class="home-subheading">Read the reference</h3>
         <p>Endpoints for plants, species, genus, families, distributions and corrections, with filters, sorting and pagination.</p>
       </li>


### PR DESCRIPTION
Ergonomics and de-templating pass on the home page, checked visually in Chrome at each step.

**Stacked on #317** (about), the tail of the #315 → #316 → #317 chain; bases retarget as they merge.

## Changes

- **Section title alignment**: `.home-section-heading` shifts left by exactly the icon + gap width (2.5rem) on viewports ≥ 1080px, so the serif H2 text lines up with the section body's left axis and the duotone icon hangs in the margin. Narrower screens keep the inline icon (no room in the margin).
- **For developers**: the `01 / 02 / 03` step numbers are removed. The step headings are the labels; the `<ol>` keeps the sequence for assistive tech. (`home-steps__index` CSS removed with it.)
- **No more stray horizontal scrollbars**: the curl sample wraps (`pre-wrap` + `overflow-wrap: anywhere`), and the live-demo command line uses `wrapLongLines` — react-syntax-highlighter pins `white-space: pre` inline on its `<code>` tag, so that prop is the only clean way (verified in the DOM: 3 wrapped lines, zero overflow). The JSON response block deliberately keeps its scroll: payloads are data, not prose.
- **Accessibility**: muted secondary text (`#7a7a7a`) measures **4.3:1 on white, under WCAG AA's 4.5:1**. It moves to a single `$text-muted` variable at `#6e6e6e` (5.1:1), swapped across all section stylesheets (home, explore, about, navbar, footer) so the grey stays uniform sitewide; legacy `#6f6f6f` literals folded into the same variable.

## Verification

- Chrome pass at desktop width: headings aligned on the content axis on all six sections (including the two-column Support section), numbering gone, terminal and curl blocks scrollbar-free.
- RSpec: 1051 examples, 0 failures. RuboCop: no offenses. `yarn build` clean.

Touches: app/views/home/_developers.html.erb, app/assets/javascripts/sections/, app/assets/javascripts/home/codesandbox.js