### PR TITLE
Expose each upstream source's licence in the API (sources[].licence)

### DIFF
--- a/app/models/foreign_source.rb
+++ b/app/models/foreign_source.rb
@@ -10,6 +10,8 @@
 #  updated_at         :datetime         not null
 #  copyright_template :text
 #  created_at         :datetime
+#  licence            :string
+#  licence_url        :string
 #
 # Indexes
 #

--- a/app/serializers/foreign_sources_plant_serializer.rb
+++ b/app/serializers/foreign_sources_plant_serializer.rb
@@ -28,7 +28,7 @@
 
 class ForeignSourcesPlantSerializer < BaseSerializer
 
-  attributes :id, :name, :url, :citation, :last_update
+  attributes :id, :name, :url, :citation, :last_update, :licence, :licence_url
 
   def id
     object.fid
@@ -44,6 +44,14 @@ class ForeignSourcesPlantSerializer < BaseSerializer
 
   def citation
     object&.citation
+  end
+
+  def licence
+    object&.foreign_source&.licence
+  end
+
+  def licence_url
+    object&.foreign_source&.licence_url
   end
 
 end

--- a/app/workers/migrators/source_licences_worker.rb
+++ b/app/workers/migrators/source_licences_worker.rb
@@ -1,0 +1,8 @@
+class Migrators::SourceLicencesWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: :migrations, retry: true, backtrace: true
+
+  def perform(*_args)
+    ::Migrators::SourceLicences.run
+  end
+end

--- a/db/migrate/20260907110000_add_licence_to_foreign_sources.rb
+++ b/db/migrate/20260907110000_add_licence_to_foreign_sources.rb
@@ -1,0 +1,10 @@
+class AddLicenceToForeignSources < ActiveRecord::Migration[8.0]
+  def change
+    # Machine-readable upstream licence for this source's data (#318).
+    # SPDX identifier where one exists (CC-BY-4.0, CC0-1.0), free text
+    # otherwise. NULL means unverified — never guessed.
+    # Backfill: Migrators::SourceLicencesWorker.
+    add_column :foreign_sources, :licence, :string
+    add_column :foreign_sources, :licence_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_09_05_160000) do
+ActiveRecord::Schema[8.0].define(version: 2026_09_07_110000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -94,6 +94,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_05_160000) do
     t.datetime "updated_at", precision: nil, null: false
     t.text "copyright_template"
     t.datetime "created_at", precision: nil
+    t.string "licence"
+    t.string "licence_url"
     t.index ["name"], name: "foreign_sources_name_index", unique: true
     t.index ["slug"], name: "foreign_sources_slug_index", unique: true
   end

--- a/lib/migrators/source_licences.rb
+++ b/lib/migrators/source_licences.rb
@@ -1,0 +1,41 @@
+# Seeds the upstream licence of each foreign source (#318), verified
+# 2026-09-07. Only sources with a confirmed licence are seeded here — every
+# other source (IPNI, PlantNet, pfaf, flora_*...) stays NULL, never guessed.
+#
+# Matches by slug only, and never creates a ForeignSource: `db/botanic_seeds.rb`
+# (the tracked seed data) has no WFO entry, so if production hasn't crawled a
+# WFO-linked species yet, that row doesn't exist and this run no-ops for it —
+# safe to re-run once it does.
+module Migrators
+  class SourceLicences
+
+    CC_BY_4_0 = {
+      licence: 'CC-BY-4.0',
+      licence_url: 'https://creativecommons.org/licenses/by/4.0/'
+    }.freeze
+
+    LICENCES = {
+      'powo' => CC_BY_4_0,
+      'gbif' => CC_BY_4_0,
+      'wfo' => {
+        licence: 'CC0-1.0',
+        licence_url: 'https://creativecommons.org/publicdomain/zero/1.0/'
+      },
+      'usda' => {
+        licence: 'Public domain (US Gov)',
+        licence_url: 'https://www.usa.gov/government-works'
+      }
+    }.freeze
+
+    def self.run
+      LICENCES.each do |slug, attrs|
+        fs = ForeignSource.find_by(slug: slug)
+
+        next unless fs
+
+        fs.update!(attrs)
+      end
+    end
+
+  end
+end

--- a/lib/schemas/v1/source.rb
+++ b/lib/schemas/v1/source.rb
@@ -8,7 +8,9 @@ module Schemas
             name: { type: :string },
             url: { type: :string, nullable: true },
             last_update: { type: :string },
-            citation: { type: :string, nullable: true }
+            citation: { type: :string, nullable: true },
+            licence: { type: :string, nullable: true, description: 'The SPDX identifier of the licence this source publishes its data under, when known' },
+            licence_url: { type: :string, nullable: true, description: 'A link to the full text of the licence' }
           },
           extras: { required: %w[name last_update] }
         )

--- a/lib/schemas/v1/species.rb
+++ b/lib/schemas/v1/species.rb
@@ -249,7 +249,9 @@ module Schemas
               name: { type: :string, description: 'The name of the source' }, # "(Douglas ex D.Don) Lindl.",
               citation: { type: :string, nullable: true, description: 'How to cite the source' }, # "(Douglas ex D.Don) Lindl.",
               url: { type: :string, nullable: true, description: 'The link on the source website, or the publication reference' }, # "(Douglas ex D.Don) Lindl.",
-              last_update: { type: :string, description: 'The last time the source was checked' } # "(Douglas ex D.Don) Lindl.",
+              last_update: { type: :string, description: 'The last time the source was checked' }, # "(Douglas ex D.Don) Lindl.",
+              licence: { type: :string, nullable: true, description: 'The SPDX identifier of the licence this source publishes its data under, when known' },
+              licence_url: { type: :string, nullable: true, description: 'A link to the full text of the licence' }
             }, extras: { description: 'The symonyms scientific names and authors' })
 
           }, extras: { description: '' }),

--- a/spec/lib/migrators_spec.rb
+++ b/spec/lib/migrators_spec.rb
@@ -110,6 +110,39 @@ RSpec.describe Migrators do
     end
   end
 
+  describe Migrators::SourceLicences do
+    it 'seeds the verified licence onto a confirmed source' do
+      powo = ForeignSource.find_by!(slug: 'powo')
+
+      described_class.run
+
+      expect(powo.reload.licence).to eq('CC-BY-4.0')
+      expect(powo.reload.licence_url).to eq('https://creativecommons.org/licenses/by/4.0/')
+    end
+
+    it 'seeds a source that is not part of the fixed seed set (WFO)' do
+      wfo = ForeignSource.create!(name: 'World Flora Online', slug: 'wfo')
+
+      described_class.run
+
+      expect(wfo.reload.licence).to eq('CC0-1.0')
+    end
+
+    it 'leaves an unconfirmed source at NULL rather than guess' do
+      plantnet = ForeignSource.find_by!(slug: 'plantnet')
+
+      described_class.run
+
+      expect(plantnet.reload.licence).to be_nil
+    end
+
+    it 'is a no-op for a source outside the verified set' do
+      openfarm = ForeignSource.find_by!(slug: 'openfarm')
+
+      expect { described_class.run }.not_to(change { openfarm.reload.licence })
+    end
+  end
+
   describe Migrators::Metrics do
     it 'leaves species alone once their heights are already recorded (current data state)' do
       Species.update_all(maximum_height_cm: 100)

--- a/spec/requests/api/v1/species_source_licences_spec.rb
+++ b/spec/requests/api/v1/species_source_licences_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+describe 'GET /api/v1/species/:id — sources[].licence', type: :request do
+  let(:user) { create(:user) }
+  let(:species) { create(:species) }
+
+  before do
+    powo = ForeignSource.find_by!(slug: 'powo')
+    plantnet = ForeignSource.find_by!(slug: 'plantnet')
+    Migrators::SourceLicences.run
+
+    ForeignSourcesPlant.create!(species: species, foreign_source: powo, fid: 'powo-fid')
+    ForeignSourcesPlant.create!(species: species, foreign_source: plantnet, fid: 'plantnet-fid')
+  end
+
+  it 'surfaces the verified upstream licence on a POWO-linked source entry' do
+    get "/api/v1/species/#{species.id}", params: { token: user.token }
+    sources = JSON.parse(response.body).dig('data', 'sources')
+
+    powo_entry = sources.find {|s| s['id'] == 'powo-fid' }
+
+    expect(response).to have_http_status(:success)
+    expect(powo_entry['licence']).to eq('CC-BY-4.0')
+    expect(powo_entry['licence_url']).to eq('https://creativecommons.org/licenses/by/4.0/')
+  end
+
+  it 'leaves licence NULL on a source with no verified licence' do
+    get "/api/v1/species/#{species.id}", params: { token: user.token }
+    sources = JSON.parse(response.body).dig('data', 'sources')
+
+    plantnet_entry = sources.find {|s| s['id'] == 'plantnet-fid' }
+
+    expect(plantnet_entry['licence']).to be_nil
+    expect(plantnet_entry['licence_url']).to be_nil
+  end
+end


### PR DESCRIPTION
Closes #318

Every species payload already carries a `sources` array via `ForeignSourcesPlantSerializer`, but it only gave the source name, external id and URL. This surfaces the upstream licence as a first-class, machine-readable field on each source entry.

## Changes

- Migration: adds nullable `licence`/`licence_url` (string) to `foreign_sources`.
- `Migrators::SourceLicences` (+ `Migrators::SourceLicencesWorker`) seeds the verified licences only: POWO and GBIF → `CC-BY-4.0`, WFO → `CC0-1.0`, USDA → `Public domain (US Gov)`. IPNI, PlantNet and everything else stay `NULL` — never guessed, per the issue's explicit instruction to leave IPNI unconfirmed despite its licence column.
- `ForeignSourcesPlantSerializer` now exposes `licence`/`licence_url`, delegated from `foreign_source` — no N+1, the serializer already `.includes(:foreign_source)`.
- `lib/schemas/v1/source.rb` and the inline `sources` schema in `lib/schemas/v1/species.rb` updated to match; no rswag/swagger doc describes the sources block separately, so nothing else to update there.

## Known limitation

`db/botanic_seeds.rb` (the tracked seed data) has no WFO entry — WFO sources are created dynamically by a gitignored crawler. The migrator matches by slug only and never creates a `ForeignSource` (matching the "never guess" rule), so if production hasn't crawled a WFO-linked species yet, that row doesn't exist yet and this migrator no-ops for it. Safe to re-run once it does — documented in the migrator's comment.

## Testing

- `spec/lib/migrators_spec.rb`: new `Migrators::SourceLicences` examples (seeds a confirmed source, seeds a source outside the tracked seed set, leaves an unconfirmed source NULL, no-ops for sources outside the verified set).
- `spec/requests/api/v1/species_source_licences_spec.rb`: `GET /api/v1/species/:id` shows `licence: "CC-BY-4.0"` on a POWO-linked source and `licence: null` on an unverified (PlantNet) one.
- Full suite green: 1040 examples, 0 failures. RuboCop and Brakeman both clean.

Touches: db/migrate, app/models/foreign_source.rb, app/serializers/foreign_sources_plant_serializer.rb, app/workers/migrators, lib/migrators, lib/schemas, spec