### PR TITLE
Terms acceptance at signup with a binding attribution clause

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,11 +1,13 @@
 class ApplicationController < ActionController::Base
+  include RequiresTermsAcceptance
+
   protect_from_forgery with: :null_session
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :set_sentry_context
   before_action :set_meta
 
   def configure_permitted_parameters
-    added_attrs = %I[name account_type email password password_confirmation remember_me organization_name organization_url]
+    added_attrs = %I[name account_type email password password_confirmation remember_me organization_name organization_url accepts_terms]
     devise_parameter_sanitizer.permit :sign_up, keys: added_attrs
     devise_parameter_sanitizer.permit :account_update, keys: added_attrs
   end

--- a/app/controllers/concerns/requires_terms_acceptance.rb
+++ b/app/controllers/concerns/requires_terms_acceptance.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Shared by every controller that renders the public web app (see
+# ApplicationController and Explore::ExploreController): a signed-in visitor
+# whose terms_accepted_at/terms_version is missing or stale gets sent to
+# accept the current version (TermsAcceptancesController) before doing
+# anything else -- browsing explore/ pages, submitting a record correction,
+# managing their profile, etc.
+#
+# Deliberately NOT included in Management::ManagementController (the admin
+# back office -- gating it risks locking out an admin over a UX detail) or
+# anywhere in the JSON API (Api::ApiController is a separate
+# ActionController::API stack that never sees this concern; the
+# `controller_path.start_with?('api/')` guard below also covers the one
+# pre-existing quirk where Api::V1::HomeController inherits
+# ApplicationController directly instead of Api::ApiController). API access
+# is never gated on this (#320).
+module RequiresTermsAcceptance
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :require_terms_acceptance!
+  end
+
+  private
+
+  def require_terms_acceptance!
+    return unless user_signed_in?
+    return if devise_controller?
+    return if controller_path == 'terms_acceptances'
+    return if controller_path.start_with?('api/')
+    return if current_user.terms_up_to_date?
+
+    redirect_to new_terms_acceptance_path(return_to: request.fullpath)
+  end
+end

--- a/app/controllers/explore/explore_controller.rb
+++ b/app/controllers/explore/explore_controller.rb
@@ -1,5 +1,6 @@
 class Explore::ExploreController < ActionController::Base
   include Pagy::Backend
+  include RequiresTermsAcceptance
 
   layout 'application'
   before_action :generate_jwt

--- a/app/controllers/terms_acceptances_controller.rb
+++ b/app/controllers/terms_acceptances_controller.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# One-time prompt shown to a signed-in web visitor whose terms acceptance is
+# missing or stale (see RequiresTermsAcceptance and TERMS_VERSION in
+# config/initializers/terms.rb). Covers both pre-existing users (accepted an
+# older version, or never recorded one) and brand new GitHub OAuth sign-ups,
+# which have no interactive step to show a checkbox during the callback
+# itself. Never runs against the JSON API: Api::ApiController is a separate
+# ActionController::API stack that never includes RequiresTermsAcceptance, so
+# tokens keep working regardless of whether this prompt has been accepted
+# (#320).
+class TermsAcceptancesController < ApplicationController
+  before_action :authenticate_user!
+
+  def new
+    @return_to = safe_return_to(params[:return_to])
+  end
+
+  def create
+    if truthy_param?(params.dig(:user, :accepts_terms))
+      current_user.accepts_terms = true
+      current_user.save!
+      redirect_to safe_return_to(params[:return_to]), notice: 'Thanks -- your acceptance of the Terms of Use has been recorded.'
+    else
+      @return_to = safe_return_to(params[:return_to])
+      flash.now[:alert] = 'You must accept the Terms of Use to keep using the Trefle website.'
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def truthy_param?(value)
+    ActiveModel::Type::Boolean.new.cast(value)
+  end
+
+  # `return_to` comes from an untrusted query/hidden-field param -- only
+  # honor same-site paths so it can't be turned into an open redirect.
+  def safe_return_to(path)
+    return root_path if path.blank? || !path.start_with?('/') || path.start_with?('//')
+
+    path
+  end
+end

--- a/app/controllers/terms_acceptances_controller.rb
+++ b/app/controllers/terms_acceptances_controller.rb
@@ -36,8 +36,14 @@ class TermsAcceptancesController < ApplicationController
 
   # `return_to` comes from an untrusted query/hidden-field param -- only
   # honor same-site paths so it can't be turned into an open redirect.
+  # Beyond a literal `//` prefix, reject backslashes and ASCII tab/newline/CR:
+  # browsers normalize `\` to `/` for special schemes, and strip tab/newline/CR
+  # entirely before resolving a Location header (WHATWG URL spec), so either
+  # one can smuggle a same-site-looking path (e.g. `/\evil.com`) into a
+  # protocol-relative redirect once the browser parses it.
   def safe_return_to(path)
-    return root_path if path.blank? || !path.start_with?('/') || path.start_with?('//')
+    return root_path if path.blank? || path.match?(/[\\\t\n\r]/)
+    return root_path if !path.start_with?('/') || path.start_with?('//')
 
     path
   end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -5,6 +5,15 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # before_action :configure_account_update_params, only: [:update]
   prepend_before_action :check_captcha, only: [:create] # Change this to be any actions you want to protect.
 
+  # Only the public sign-up form enforces the terms-acceptance checkbox
+  # (see User#enforce_terms_acceptance) -- GitHub OAuth sign-ups and
+  # admin-created users go through other paths that don't call
+  # build_resource, so they're unaffected.
+  def build_resource(hash = {})
+    super
+    resource.enforce_terms_acceptance = true
+  end
+
   private
 
   def check_captcha

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,6 +31,8 @@
 #  sign_in_count          :integer          default(0)
 #  sponsored_tier         :string
 #  sponsorship_checked_at :datetime
+#  terms_accepted_at      :datetime
+#  terms_version          :string
 #  token                  :string(255)
 #  uid                    :string
 #  unconfirmed_email      :string
@@ -68,6 +70,24 @@ class User < ApplicationRecord
     other
   ].freeze
 
+  # Virtual checkbox for the terms-acceptance form(s). Only the public
+  # sign-up form (Users::RegistrationsController) turns on
+  # `enforce_terms_acceptance`, so this validation never blocks the admin
+  # back-office (management/users) or the GitHub OAuth callback -- both
+  # create users directly. GitHub sign-ups instead pick up the acceptance
+  # prompt on their first web page load, same as pre-existing users
+  # (see RequiresTermsAcceptance#require_terms_acceptance!).
+  attr_accessor :enforce_terms_acceptance
+
+  validates :accepts_terms, acceptance: { message: 'must be accepted to create an account' }, if: :enforce_terms_acceptance
+
+  before_save :record_terms_acceptance, if: :accepts_terms
+
+  # Whether this user has accepted the currently published Terms of Use.
+  def terms_up_to_date?
+    terms_accepted_at.present? && terms_version == TERMS_VERSION
+  end
+
   def get_token
     if admin
       "unl-#{SecureRandom.urlsafe_base64(32)}"
@@ -89,6 +109,11 @@ class User < ApplicationRecord
   def regenerate_token_if_plan_changed!
     new_token = get_token
     update(token: new_token) if token.slice(0, 3) != new_token.slice(0, 3)
+  end
+
+  def record_terms_acceptance
+    self.terms_accepted_at = Time.current
+    self.terms_version = TERMS_VERSION
   end
 
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -58,6 +58,8 @@
     </div>
   </div>
 
+  <%= render "shared/terms_checkbox_field" %>
+
   <div class="field">
     <div class="control">
       <%= recaptcha_tags %>

--- a/app/views/home/licence.erb
+++ b/app/views/home/licence.erb
@@ -61,9 +61,21 @@
       <p>Certain names, titles, trademarks, service marks, and logos that appear on Trefle are registered or common law (unregistered) marks owned by Trefle members, Trefle content providers, or third parties. With the exception of fair use, you may not use such trademarks without the owner’s prior written permission. Nothing on Trefle shall be construed as granting any license to use any trademark displayed on Trefle without the express written permission of the owner of the trademark.</p>
     </section>
 
+    <section class="section content" id="attribution">
+      <h1 class="title is-4 ">
+        <%= fa_icon('book-heart', class: 'has-text-success') %> Attribution
+      </h1>
+      <p>Trefle's own data (species records, taxonomy, corrections contributed by the community) is licensed under the <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" rel="noopener">Creative Commons Attribution 4.0 International licence (CC BY 4.0)</a>. Data pulled in from upstream sources keeps that source's own licence -- check the <code>sources</code> array of the API response, or the source's entry, for the licence that actually applies to a given record.</p>
+      <ul>
+        <li>If your application displays Trefle data, show <strong>"Data: Trefle.io (CC BY 4.0)"</strong> next to it, linked to <%= link_to "trefle.io", root_url %>.</li>
+        <li>If you use Trefle data in a publication, cite Trefle using the canonical citation (formats are available on the citation page once published; in the meantime, cite "Trefle, https://trefle.io").</li>
+        <li>By accepting these Terms of Use at sign-up, you agree to this attribution clause -- it is what makes crediting Trefle and its upstream sources binding on every application built on the API, wherever it runs.</li>
+      </ul>
+    </section>
+
     <section class="section content" id="other">
       <p>Trefle reserves the right to change these Terms of Use from time to time without notice; changes shall be effective upon posting. Please check back regularly for updates. Failure of Trefle to enforce any of these terms shall not constitute a waiver of such terms.</p>
-      <p><i>Last modified on Wed, 15 Jul 2020</i></p>
+      <p><i>Last modified on <%= Date.parse(TERMS_VERSION).strftime('%a, %-d %b %Y') %> (version <%= TERMS_VERSION %>)</i></p>
     </section>
 
     <hr>

--- a/app/views/shared/_terms_checkbox_field.html.erb
+++ b/app/views/shared/_terms_checkbox_field.html.erb
@@ -1,0 +1,15 @@
+<%# locals: (show_version: false) %>
+<div class="field">
+  <div class="control">
+    <label class="checkbox">
+      <%# check_box_tag alone has no "unchecked" fallback (unlike f.check_box) --
+          an unticked box would submit no param at all, which the acceptance
+          validator treats as "field not present" rather than "declined", and
+          silently lets the request through. The hidden field pins it to "0"
+          when left unchecked, same trick Rails' own check_box helper uses. %>
+      <%= hidden_field_tag 'user[accepts_terms]', '0' %>
+      <%= check_box_tag 'user[accepts_terms]', '1', false %>
+      I have read and accept the <%= link_to "Terms of Use", terms_path, target: "_blank", rel: "noopener" %><% if show_version %> (version <%= TERMS_VERSION %>)<% end %>.
+    </label>
+  </div>
+</div>

--- a/app/views/terms_acceptances/new.html.erb
+++ b/app/views/terms_acceptances/new.html.erb
@@ -1,0 +1,29 @@
+<div class="home-page container">
+  <section class="hero">
+    <div class="hero-body">
+      <div class="container">
+        <h1 class="title is-1">
+          <%= fa_icon('file-contract', class: 'has-text-primary') %>
+          Updated Terms of Use
+        </h1>
+        <h2 class="subtitle">
+          Please accept the current Terms of Use to keep using the Trefle website. Your API access is not affected either way.
+        </h2>
+      </div>
+    </div>
+  </section>
+
+  <section class="section content">
+    <%= form_with url: terms_acceptance_path, method: :post, local: true, html: { class: 'auth-page' } do %>
+      <%= hidden_field_tag :return_to, @return_to %>
+
+      <%= render "shared/terms_checkbox_field", show_version: true %>
+
+      <div class="field">
+        <div class="control">
+          <%= submit_tag 'Accept and continue', class: 'button is-primary' %>
+        </div>
+      </div>
+    <% end %>
+  </section>
+</div>

--- a/config/initializers/terms.rb
+++ b/config/initializers/terms.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Version tag for the Terms of Use (see /terms). Bump this string whenever
+# the terms change materially -- every user, new or already registered, is
+# then asked to accept the new version once, on their next visit to the web
+# app (see ApplicationController#require_terms_acceptance!). API access is
+# never gated on this: tokens keep working regardless (#320).
+TERMS_VERSION = '2026-09-07'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
   get '/donate', to: 'home#donate', as: 'donate'
   get '/terms', to: 'home#licence', as: 'terms'
   get '/profile', to: 'profile#index', as: 'profile'
+  resource :terms_acceptance, only: %i[new create]
 
   namespace 'api' do
     namespace 'v1' do

--- a/db/migrate/20260907102227_add_terms_acceptance_to_users.rb
+++ b/db/migrate/20260907102227_add_terms_acceptance_to_users.rb
@@ -1,0 +1,6 @@
+class AddTermsAcceptanceToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :terms_accepted_at, :datetime
+    add_column :users, :terms_version, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_09_05_160000) do
+ActiveRecord::Schema[8.0].define(version: 2026_09_07_102227) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -712,6 +712,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_05_160000) do
     t.string "github_username"
     t.string "sponsored_tier"
     t.datetime "sponsorship_checked_at"
+    t.datetime "terms_accepted_at"
+    t.string "terms_version"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["email"], name: "users_email_index", unique: true

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -6,6 +6,12 @@ FactoryBot.define do
     password_confirmation { password }
 
     admin { false }
+    # Most specs just want a user free to use the web app; a signed-in user
+    # with terms_accepted_at blank would otherwise get redirected to the
+    # terms-acceptance prompt (see RequiresTermsAcceptance#require_terms_acceptance!).
+    # Use `create(:user, accepts_terms: false)` to get a user still pending
+    # acceptance.
+    accepts_terms { true }
 
     # before(:create, &:confirm)
 

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -8,12 +8,27 @@ RSpec.feature 'Sign in/up page', type: :feature do
     fill_in 'user_email',    with: 'test@lala.co'
     fill_in 'user_password', with: 'asamplepassword'
     fill_in 'user_password_confirmation', with: 'asamplepassword'
+    check 'user_accepts_terms'
     click_button 'Sign up'
 
     # Devise :confirmable is disabled on User, sign up logs the user straight in
     expect(page).to have_content 'You have signed up successfully'
-    expect(User.find_by_email('test@lala.co')).to be
+    user = User.find_by_email('test@lala.co')
+    expect(user).to be
+    expect(user.terms_accepted_at).to be_present
+    expect(user.terms_version).to eq(TERMS_VERSION)
+  end
 
+  scenario 'User cannot create an account without accepting the terms' do
+    visit '/users/sign_up'
+
+    fill_in 'user_email',    with: 'nolove@lala.co'
+    fill_in 'user_password', with: 'asamplepassword'
+    fill_in 'user_password_confirmation', with: 'asamplepassword'
+    click_button 'Sign up'
+
+    expect(page).to have_content 'must be accepted to create an account'
+    expect(User.find_by_email('nolove@lala.co')).to be_nil
   end
 
   scenario 'User can sign in' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  describe '#terms_up_to_date?' do
+    it 'is false when terms were never accepted' do
+      user = build(:user, accepts_terms: false)
+      expect(user.terms_up_to_date?).to be false
+    end
+
+    it 'is false when the accepted version is stale' do
+      user = build(:user, accepts_terms: false, terms_accepted_at: 1.year.ago, terms_version: 'old-version')
+      expect(user.terms_up_to_date?).to be false
+    end
+
+    it 'is true once the current version has been recorded' do
+      user = create(:user, accepts_terms: true)
+      expect(user.terms_up_to_date?).to be true
+    end
+  end
+
+  describe 'terms acceptance recording' do
+    it 'stamps terms_accepted_at/terms_version when accepts_terms is truthy on save' do
+      user = build(:user, accepts_terms: true, terms_accepted_at: nil, terms_version: nil)
+
+      user.save!
+
+      expect(user.terms_accepted_at).to be_present
+      expect(user.terms_version).to eq(TERMS_VERSION)
+    end
+
+    it 'does not touch terms fields when accepts_terms is falsy' do
+      user = build(:user, accepts_terms: false, terms_accepted_at: nil, terms_version: nil)
+
+      user.save!
+
+      expect(user.terms_accepted_at).to be_nil
+      expect(user.terms_version).to be_nil
+    end
+  end
+
+  describe 'accepts_terms acceptance validation' do
+    it 'does not block a plain save -- only forms that opt in via enforce_terms_acceptance do' do
+      user = build(:user, accepts_terms: false)
+      expect(user).to be_valid
+    end
+
+    it 'blocks save when enforce_terms_acceptance is set and the box was not checked' do
+      user = build(:user, accepts_terms: false)
+      user.enforce_terms_acceptance = true
+
+      expect(user).not_to be_valid
+      expect(user.errors[:accepts_terms]).to be_present
+    end
+
+    it 'passes when enforce_terms_acceptance is set and the box was checked' do
+      user = build(:user, accepts_terms: true)
+      user.enforce_terms_acceptance = true
+
+      expect(user).to be_valid
+    end
+  end
+end

--- a/spec/requests/terms_acceptances_spec.rb
+++ b/spec/requests/terms_acceptances_spec.rb
@@ -1,0 +1,141 @@
+require 'rails_helper'
+
+RSpec.describe 'Terms acceptance', type: :request do
+  # A user "pending terms" mimics an account created before this feature
+  # shipped (nil terms_accepted_at) as well as a brand new GitHub OAuth
+  # sign-up (see Users::OmniauthCallbacksController -- it never sets
+  # accepts_terms, on purpose).
+  let(:pending_user) { create(:user, accepts_terms: false) }
+
+  describe 'the web-wide gate (RequiresTermsAcceptance, included in ApplicationController and Explore::ExploreController)' do
+    it 'redirects a signed-in user with no recorded acceptance away from the app' do
+      login_as pending_user, scope: :user
+
+      get profile_path
+
+      expect(response).to redirect_to(new_terms_acceptance_path(return_to: profile_path))
+    end
+
+    it 'also gates explore/ pages, not just home/profile -- a pending user cannot browse species either' do
+      login_as pending_user, scope: :user
+
+      get explore_path
+
+      expect(response).to redirect_to(new_terms_acceptance_path(return_to: explore_path))
+    end
+
+    it 'redirects a signed-in user whose accepted version is stale' do
+      # Built stale from the start (accepts_terms: false so the before_save
+      # callback doesn't stamp it as current) rather than accepted-then-mutated:
+      # Devise's :trackable module re-saves current_user on sign-in, which
+      # would silently re-run the acceptance callback and heal the staleness
+      # if accepts_terms were still truthy on that same in-memory object.
+      stale_user = create(:user, accepts_terms: false, terms_accepted_at: 1.year.ago, terms_version: 'some-old-version')
+      login_as stale_user, scope: :user
+
+      get profile_path
+
+      expect(response).to redirect_to(new_terms_acceptance_path(return_to: profile_path))
+    end
+
+    it 'lets a user who is up to date through untouched' do
+      login_as create(:user), scope: :user
+
+      get profile_path
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'does not gate anonymous visitors' do
+      get root_path
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'does not gate Devise pages, so a pending user can still sign out' do
+      login_as pending_user, scope: :user
+
+      get edit_user_registration_path
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'never gates the JSON API -- a token keeps working regardless of pending terms' do
+      get '/api/v1/me', headers: { 'Authorization' => "Bearer #{pending_user.token}" }
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'never gates /api/v1 routes even for a browser session with a pending-terms cookie (Api::V1::HomeController oddly inherits ApplicationController)' do
+      login_as pending_user, scope: :user
+
+      get '/api/v1/'
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'GET /terms_acceptance/new' do
+    it 'redirects anonymous visitors to sign in' do
+      get new_terms_acceptance_path
+
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it 'renders the prompt for a pending user' do
+      login_as pending_user, scope: :user
+
+      get new_terms_acceptance_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('Terms of Use')
+    end
+  end
+
+  describe 'POST /terms_acceptance' do
+    it 'records acceptance and redirects to return_to when the box is checked' do
+      login_as pending_user, scope: :user
+
+      post terms_acceptance_path, params: { user: { accepts_terms: '1' }, return_to: profile_path }
+
+      expect(response).to redirect_to(profile_path)
+      pending_user.reload
+      expect(pending_user.terms_accepted_at).to be_present
+      expect(pending_user.terms_version).to eq(TERMS_VERSION)
+    end
+
+    it 'falls back to root_path when return_to is missing' do
+      login_as pending_user, scope: :user
+
+      post terms_acceptance_path, params: { user: { accepts_terms: '1' } }
+
+      expect(response).to redirect_to(root_path)
+    end
+
+    it 'ignores an off-site return_to (open-redirect guard)' do
+      login_as pending_user, scope: :user
+
+      post terms_acceptance_path, params: { user: { accepts_terms: '1' }, return_to: 'https://evil.example/phish' }
+
+      expect(response).to redirect_to(root_path)
+    end
+
+    it 'refuses to record acceptance when the box is left unchecked' do
+      login_as pending_user, scope: :user
+
+      post terms_acceptance_path, params: { user: { accepts_terms: '0' } }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(pending_user.reload.terms_accepted_at).to be_nil
+    end
+
+    it 'lets a freshly accepted user through the gate on the very next request' do
+      login_as pending_user, scope: :user
+      post terms_acceptance_path, params: { user: { accepts_terms: '1' } }
+
+      get profile_path
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/requests/terms_acceptances_spec.rb
+++ b/spec/requests/terms_acceptances_spec.rb
@@ -120,6 +120,22 @@ RSpec.describe 'Terms acceptance', type: :request do
       expect(response).to redirect_to(root_path)
     end
 
+    it 'ignores a backslash return_to that browsers normalize into a protocol-relative redirect' do
+      login_as pending_user, scope: :user
+
+      post terms_acceptance_path, params: { user: { accepts_terms: '1' }, return_to: '/\\evil.example' }
+
+      expect(response).to redirect_to(root_path)
+    end
+
+    it 'ignores a mixed slash/backslash return_to' do
+      login_as pending_user, scope: :user
+
+      post terms_acceptance_path, params: { user: { accepts_terms: '1' }, return_to: '/\\/evil.example' }
+
+      expect(response).to redirect_to(root_path)
+    end
+
     it 'refuses to record acceptance when the box is left unchecked' do
       login_as pending_user, scope: :user
 

--- a/spec/requests/users/omniauth_callbacks_spec.rb
+++ b/spec/requests/users/omniauth_callbacks_spec.rb
@@ -31,6 +31,12 @@ RSpec.describe 'Users::OmniauthCallbacks', type: :request do
       expect(user.provider).to eq('github')
       expect(user.uid).to eq('999')
       expect(response).to redirect_to(root_path)
+
+      # GitHub sign-up has no interactive step of its own to show the terms
+      # checkbox, so the account starts out pending -- the web-wide gate
+      # (RequiresTermsAcceptance#require_terms_acceptance!) picks it up on the
+      # very next page load instead (see spec/requests/terms_acceptances_spec.rb).
+      expect(user.terms_accepted_at).to be_nil
     end
 
     it 'signs in an existing user matched by provider and uid' do

--- a/spec/requests/web/home_spec.rb
+++ b/spec/requests/web/home_spec.rb
@@ -42,6 +42,12 @@ RSpec.describe 'Public website pages', type: :request do
       get terms_path
       expect(response).to have_http_status(:ok)
     end
+
+    it 'names the data licence and the attribution clause (#320)' do
+      get terms_path
+      expect(response.body).to include('CC BY 4.0')
+      expect(response.body).to include('Data: Trefle.io')
+    end
   end
 
   describe 'GET /profile' do


### PR DESCRIPTION
Closes #320

## Summary

- Migration adds `users.terms_accepted_at` / `users.terms_version`; `TERMS_VERSION` in `config/initializers/terms.rb` is the one-line bump point for future terms changes.
- Email sign-up requires an explicit, unchecked-by-default checkbox. Enforced via `User#enforce_terms_acceptance`, turned on only by the public registration form (`Users::RegistrationsController#build_resource`) — the admin back office (`management/users`) and GitHub OAuth account creation are unaffected by that validation.
- GitHub OAuth sign-up has no interactive step of its own before the account is created (`Users::OmniauthCallbacksController` creates the `User` directly in the callback). Rather than blocking creation, the account starts out pending (`terms_accepted_at` nil) and is picked up by the same gate used for pre-existing users.
- New `RequiresTermsAcceptance` concern, included in `ApplicationController` and `Explore::ExploreController`, redirects a signed-in user with missing/stale terms to `TermsAcceptancesController` before they can do anything else on the web app (browsing, submitting record corrections, profile, etc). Deliberately **not** included in `Management::ManagementController` (admin back office) or anywhere in the JSON API stack (`Api::ApiController`) — API tokens keep working regardless, including for the pre-existing `Api::V1::HomeController < ApplicationController` quirk (explicit guard).
- `/terms` now names the CC BY 4.0 data licence and the attribution clause ("Data: Trefle.io (CC BY 4.0)" + citation guidance), per #285 (closed, CC BY 4.0 decided 2026-09-07).

## Notes for the reviewer

- A subtle one caught in review: the shared checkbox partial originally used a bare `check_box_tag`, which (unlike `f.check_box`) has no hidden "0" fallback — an unticked box submitted no param at all, and the acceptance validator treats a genuinely unset attribute as not-applicable rather than "declined", silently letting signup through unchecked. Fixed by adding the hidden fallback field explicitly (see `app/views/shared/_terms_checkbox_field.html.erb`); covered by a feature spec.
- `db/schema.rb` in this PR reflects only this branch's migration — the shared local Postgres between concurrent worktree sessions can otherwise leak unrelated in-flight schema state into a fresh `db:migrate` dump, so I reset it to master + this migration only.

## Testing

- Full RSpec suite: 1059 examples, 0 failures.
- RuboCop: 0 offenses.
- Brakeman: 0 warnings.

Touches: db/migrate, app/models/user.rb, app/controllers (users/, terms_acceptances, concerns), app/views (devise/registrations, home/licence, terms_acceptances, shared), config, spec