### PR TITLE
Chrome consistency: aligned navbar, square cards, institutional account page

### DIFF
--- a/app/assets/javascripts/application.scss
+++ b/app/assets/javascripts/application.scss
@@ -14,6 +14,7 @@
 @import 'sections/explore';
 @import 'sections/about';
 @import 'sections/donate';
+@import 'sections/profile';
 @import 'sections/navbar';
 @import 'sections/footer';
 

--- a/app/assets/javascripts/sections/_explore.scss
+++ b/app/assets/javascripts/sections/_explore.scss
@@ -170,14 +170,16 @@
   align-items: stretch;
   flex-direction: column;
 
+  // Every card shows the same square frame: portrait herbarium scans and
+  // landscape field photos are cropped by the object-fit:cover img below,
+  // and the leaf placeholder fills the identical square.
   aside {
-    min-width: 100px;
-    min-height: 150px;
-    height: 100%;
+    aspect-ratio: 1 / 1;
     display: flex;
     margin: 10px 0;
     border-radius: 3px;
     overflow: hidden;
+    width: 100%;
   }
 
   main {

--- a/app/assets/javascripts/sections/_navbar.scss
+++ b/app/assets/javascripts/sections/_navbar.scss
@@ -6,17 +6,30 @@
 // stays Bulma's own navbar/navbar-burger/navbar-menu markup so the existing
 // mobile burger toggle (application.js) keeps working unmodified — only the
 // look is restyled here.
-// Bulma's own .container caps at 960px on desktop (see bulma/elements/
-// container.sass's $desktop - $container-offset); the maquette wants 1040px
-// (see #304 / #312 review) so this overrides it specifically for the navbar,
-// without touching .container's default elsewhere on the site.
-.site-navbar-container {
-  max-width: $layout-max-width;
+// The hairline spans the full viewport; the nav content sits in the same
+// 1040px + 1.5rem-padding container as every page body, so the brand and the
+// first heading below share a left axis. No Bulma .container here: its
+// responsive caps use :not() selectors that outweigh a plain class override.
+.site-header {
+  background: #fff;
+  border-bottom: 1px solid #dbdbdb;
+
+  &__inner {
+    box-sizing: border-box;
+    margin: 0 auto;
+    max-width: $layout-max-width;
+    padding: 0 1.5rem;
+  }
 }
 
 .navbar.site-navbar {
-  border-bottom: 1px solid #dbdbdb;
   min-height: 4rem;
+
+  // Bulma gives every .navbar-item a 0.75rem side padding; on the first item
+  // (the brand) that breaks the shared left axis with the page content.
+  .navbar-brand .brand-link {
+    padding-left: 0;
+  }
 
   .navbar-brand {
     align-items: center;

--- a/app/assets/javascripts/sections/_profile.scss
+++ b/app/assets/javascripts/sections/_profile.scss
@@ -1,0 +1,80 @@
+@import "variables";
+
+// Account page bits on top of the shared .about section structure.
+
+.profile-token {
+  background: #f5f5f5;
+  border: 1px solid #dbdbdb;
+  border-radius: 4px;
+  box-sizing: border-box;
+  color: #363636;
+  font-family: $family-monospace;
+  font-size: 0.875rem;
+  max-width: 40rem;
+  padding: 0.6rem 0.9rem;
+  width: 100%;
+
+  &:focus {
+    border-color: $forest-green;
+    outline: none;
+  }
+}
+
+.profile-rate {
+  font-size: 0.9375rem;
+  margin: 0;
+
+  .home-mono {
+    color: #0a0a0a;
+  }
+
+  &__crown {
+    color: #f39c12;
+    display: inline-flex;
+  }
+}
+
+.profile-details {
+  display: flex;
+  flex-direction: column;
+  margin: 0;
+
+  &__row {
+    border-top: 1px solid #dbdbdb;
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: 10rem minmax(0, 1fr);
+    padding: 0.6rem 0;
+
+    dt {
+      color: $text-muted;
+      font-size: 0.875rem;
+    }
+
+    dd {
+      margin: 0;
+      overflow-wrap: anywhere;
+    }
+
+    @include respond-to(handhelds) {
+      grid-template-columns: minmax(0, 1fr);
+      gap: 0.15rem;
+    }
+  }
+}
+
+.profile-actions {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+
+  form {
+    display: inline-flex;
+  }
+}
+
+.profile-danger-note {
+  color: $text-muted;
+  font-size: 0.875rem;
+}

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -4,5 +4,7 @@ class ProfileController < ApplicationController
   # 401 redirect to the home page.
   before_action :authenticate_user!
 
-  def index; end
+  def index
+    @page_title = 'Your account'
+  end
 end

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,4 +1,5 @@
-<div class="container site-navbar-container">
+<header class="site-header">
+  <div class="site-header__inner">
   <nav class="navbar site-navbar" role="navigation" aria-label="main navigation">
     <div class="navbar-brand">
       <a class="navbar-item brand-link" href="<%= root_path %>">
@@ -59,4 +60,5 @@
       </div>
     </div>
   </nav>
-</div>
+  </div>
+</header>

--- a/app/views/profile/index.html.erb
+++ b/app/views/profile/index.html.erb
@@ -1,123 +1,114 @@
-<div class="home-page container is-fluid">
+<%# Account page in the institutional structure (same header + stacked
+    hairline sections as the about page, whose classes it reuses). %>
+<% provide :full_bleed, '1' %>
 
-  <div class="columns">
-    <div class="column is-2"></div>
-    <div class="column is-10">
-      <section class="hero">
-        <div class="hero-body">
-          <div class="container">
-            <h1 class="title is-1">
-              <%= fa_icon('key-skeleton', class: 'has-text-primary') %>
-
-              Your account
-            </h1>
-          </div>
-        </div>
-      </section>
-    </div>
-  </div>
-
-  <div class="columns">
-    <div class="column is-2">
-      <br>
-      <br>
-      <aside class="menu">
-        <ul class="menu-list">
-          <li><a href="#token-informations">Access token</a></li>
-          <li><a href="#informations">Account</a></li>
-          <li>
-            <%= link_to "Sign out", destroy_user_session_path, data: { confirm: "Are you sure?" }, method: :delete, class: "has-text-danger" %>
-          </li>
-        </ul>
-      </aside>
-    </div>
-    <div class="column is-10">
-
-      <section class="section" id="token-informations">
-        <!-- <div class="columns">
-          <div class="column"> -->
-        <p class="title is-4">
-          Access token
+<div class="about profile">
+  <header class="about__header">
+    <div class="about__heading">
+      <span class="about__heading-icon"><%= fa_icon('key') %></span>
+      <div>
+        <h1 class="about__title">Your account</h1>
+        <p class="about__lead">
+          Signed in as <span class="home-mono"><%= current_user.email %></span>.
         </p>
-        <div class="field has-addons">
-          <p class="control">
-            <a class="button is-static">
-              Your token is:
-            </a>
-          </p>
-          <p class="control is-expanded">
-            <input class="input readonly" readonly value="<%= current_user&.token %>" />
-          </p>
-        </div>
-        <p class="help">You token allow you to makes queries on the Trefle API. Keep it private.</p>
+      </div>
+    </div>
+    <nav class="about__nav" aria-label="Account sections">
+      <a href="#token">Access token</a>
+      <a href="#account">Account</a>
+      <a href="#danger">Sign out &amp; deletion</a>
+    </nav>
+  </header>
 
-        <br />
-        <% if !current_user.sponsored_tier.present? %>
-          <div class="notification">
-            You can make <strong>60 requests per minute</strong>.
-            <br />
-            Do you need more ? Please consider <%= link_to "sponsoring us", about_path(anchor: 'support') %>
-          </div>
-        <% else %>
-          <div class="notification">
-            <strong><span class="icon" style="color: #f39c12; margin-left: 5px"><%= fa_icon('crown') %></span> You are a sponsor !</strong> Thanks a lot for helping us to keep Trefle alive. You can make up to <strong>600</strong> requests per minute.
+  <div class="about__body">
+    <section id="token" class="about-section about-section--first">
+      <div class="about-section__heading">
+        <span class="about-section__icon"><%= fa_icon('key') %></span>
+        <h2 class="about-section__title">Access token</h2>
+      </div>
+      <p>
+        Your token allows you to make queries on the Trefle API.
+        Keep it private.
+      </p>
+      <input class="profile-token" readonly value="<%= current_user&.token %>"
+             aria-label="API access token" onclick="this.select()">
+      <% if current_user.sponsored_tier.present? %>
+        <p class="profile-rate profile-rate--sponsor">
+          <span class="profile-rate__crown"><%= fa_icon('crown') %></span>
+          You are a sponsor! Thanks a lot for helping us keep Trefle alive.
+          You can make up to <span class="home-mono">600</span> requests per minute.
+        </p>
+      <% else %>
+        <p class="profile-rate">
+          You can make <span class="home-mono">60</span> requests per minute.
+          Need more? <%= link_to 'Become a sponsor', donate_path(anchor: 'sponsor') %>.
+        </p>
+      <% end %>
+    </section>
+
+    <section id="account" class="about-section">
+      <div class="about-section__heading">
+        <span class="about-section__icon"><%= fa_icon('user') %></span>
+        <h2 class="about-section__title">Account</h2>
+      </div>
+      <dl class="profile-details">
+        <div class="profile-details__row">
+          <dt>Name</dt>
+          <dd><%= current_user.name.presence || '&mdash;'.html_safe %></dd>
+        </div>
+        <div class="profile-details__row">
+          <dt>E-mail</dt>
+          <dd class="home-mono"><%= current_user.email %></dd>
+        </div>
+        <div class="profile-details__row">
+          <dt>Account type</dt>
+          <dd><%= current_user.account_type&.to_s&.humanize || 'Unknown' %></dd>
+        </div>
+        <% if current_user.organization_name.present? %>
+          <div class="profile-details__row">
+            <dt>Organization</dt>
+            <dd><%= current_user.organization_name %></dd>
           </div>
         <% end %>
-      </section>
-
-      <section class="section" id="token-informations">
-        <p class="title is-4">
-          Account informations
-        </p>
-        <ul>
-          <li>
-            <strong>Name:</strong>
-            <%= current_user.name %>
-          </li>
-          <li>
-            <strong>Account type:</strong>
-            <%= current_user.account_type&.to_s&.humanize || 'Unknown' %>
-          </li>
-          <li>
-            <strong>Email:</strong>
-            <%= current_user.email %>
-          </li>
-          <li>
-            <strong>Organization:</strong>
-            <%= current_user.organization_name %>
-          </li>
-          <li>
-            <strong>Website:</strong>
-            <%= current_user.organization_url %>
-          </li>
-          <li>
-            <strong>Password</strong>
-            <span>********</span>
-            <%= link_to "(change)", edit_user_registration_path(current_user), class: "link" %>
-          </li>
-          <li>
-            <% if !current_user.provider? %>
-              <strong>GitHub account:</strong>
-              <%= link_to 'Link my Github account', user_github_omniauth_authorize_path, method: :post, class: 'btn btn-primary' %>
-            <% else %>
-              <strong>Linked GitHub account:</strong>
-              <%= current_user.github_username %>
-            <% end %>
-          </li>
-
-
-        </ul>
-        <br />
-        <hr />
-        <br />
-        <div class="field is-grouped">
-          <p class="control">
-
-            <%= link_to "Edit your account", edit_user_registration_path(current_user), class: "button is-primary" %>
-            <%= button_to "Cancel my account", registration_path(current_user), data: { confirm: "Are you sure?" }, method: :delete, class: "button is-link is-danger" %>
-          </p>
+        <% if current_user.organization_url.present? %>
+          <div class="profile-details__row">
+            <dt>Website</dt>
+            <dd><%= link_to current_user.organization_url, current_user.organization_url %></dd>
+          </div>
+        <% end %>
+        <div class="profile-details__row">
+          <dt>Password</dt>
+          <dd>&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull; <%= link_to '(change)', edit_user_registration_path %></dd>
         </div>
-      </section>
-    </div>
+        <div class="profile-details__row">
+          <dt>GitHub</dt>
+          <dd>
+            <% if current_user.provider? %>
+              <span class="home-mono"><%= current_user.github_username %></span>
+            <% else %>
+              <%= link_to 'Link my GitHub account', user_github_omniauth_authorize_path, method: :post %>
+            <% end %>
+          </dd>
+        </div>
+      </dl>
+      <div class="profile-actions">
+        <%= link_to 'Edit your account', edit_user_registration_path, class: 'button is-primary' %>
+      </div>
+    </section>
+
+    <section id="danger" class="about-section">
+      <div class="about-section__heading">
+        <span class="about-section__icon"><%= fa_icon('hourglass-half') %></span>
+        <h2 class="about-section__title">Sign out &amp; deletion</h2>
+      </div>
+      <div class="profile-actions">
+        <%= button_to 'Sign out', destroy_user_session_path, method: :delete, class: 'button' %>
+        <%= button_to 'Cancel my account', registration_path(current_user), data: { confirm: 'Are you sure?' }, method: :delete, class: 'button is-danger is-outlined' %>
+      </div>
+      <p class="profile-danger-note">
+        Cancelling deletes your account and revokes your API token. Your
+        accepted corrections stay, attributed to your name.
+      </p>
+    </section>
   </div>
 </div>

--- a/spec/features/account_spec.rb
+++ b/spec/features/account_spec.rb
@@ -20,7 +20,8 @@ RSpec.feature 'Account page', type: :feature do
     expect(page).to have_text('Your account')
     expect(page).to have_text('Access token')
     expect(page).to have_selector("input[value='#{user.token}']")
-    expect(page).to have_text('Account informations')
+    expect(page).to have_text('Account type')
+    expect(page).to have_text('Sign out & deletion')
   end
 
 end


### PR DESCRIPTION
Three sitewide consistency fixes requested after reviewing the pages side by side. **Stacked on #329**, tail of the #327 → #317 → #323 → #329 chain.

## Changes

- **Navbar alignment**: the header hairline spans the full viewport, and the nav content sits in the same 1040px + 1.5rem-padding container as every page body — the brand logo now shares the pages' left axis (verified against the explore search field in Chrome). Root cause of the old misalignment: Bulma's responsive `.container` caps use `:not()` selectors that outweigh a plain class override, so the previous `max-width: 1040px` never applied; the header no longer uses Bulma's `.container` at all. The brand link drops Bulma's leading item padding.
- **Square cards everywhere**: the species card photo container takes `aspect-ratio: 1/1` with the existing `object-fit: cover` image — portrait herbarium scans and landscape field photos crop to the same square, and the leaf placeholder fills the identical frame instead of collapsing into a thin strip (the genus-page bug in the screenshots). Applies to the explore grid and the genus pages, which share the partial.
- **Account page** joins the institutional structure (same header + hairline sections as the about page, reusing its classes): serif "Your account" with the signed-in e-mail in mono, anchor nav, Access token section (mono readonly field, click-to-select, rate-limit line — the sponsor link now points at the donate page's sponsor section instead of the about anchor removed in #317), a label/value details grid (rows shown only when filled), and a separate "Sign out & deletion" section that isolates the destructive action and states what deletion does. Page title added.

## Verification

- Chrome pass: navbar/content left axis aligned on explore + profile, full-width hairline, square cropping on mixed portrait/landscape/placeholder rows (real Fabaceae hybrids data), account page top to bottom.
- RSpec: 1053 examples, 0 failures (account feature spec updated to the new section names, token-input assertion still passing). RuboCop: no offenses. `yarn build` clean.

Touches: app/views/layouts/_navbar.html.erb, app/views/profile/, app/controllers/profile_controller.rb, app/assets/javascripts/sections/, spec/features/account_spec.rb