### PR TITLE
Give each worktree its own test database

### DIFF
--- a/.agents/verify.sh
+++ b/.agents/verify.sh
@@ -6,12 +6,25 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-main_checkout=$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")
+main_checkout=$(cd "$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")" && pwd -P)
 for f in .env.local .env.test.local .env.development.local; do
   if [ ! -f "$f" ] && [ -f "$main_checkout/$f" ]; then
     cp "$main_checkout/$f" "$f"
   fi
 done
+
+# Several sessions run this script at once, from different worktrees, against one
+# local Postgres. `db:test:prepare` drops and recreates the test database, so two
+# runs finishing together race on it and one dies with
+#   PG::UniqueViolation ... duplicate key value violates unique constraint
+#   "pg_database_datname_index" ... Key (datname)=(trefle_test) already exists.
+# Give each worktree its own database (see config/database.yml). The main checkout
+# and CI set nothing and keep plain `trefle_test`, so nothing else changes.
+if [ "$(pwd -P)" != "$main_checkout" ]; then
+  slug=$(printf '%s' "$(basename "$(pwd -P)")" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9' '_' | cut -c1-45)
+  export PG_TEST_DATABASE="trefle_test_${slug}"
+  echo "verify: using test database ${PG_TEST_DATABASE}"
+fi
 
 bundle check >/dev/null 2>&1 || bundle install --quiet
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -59,7 +59,11 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: trefle_test
+  # Agent sessions run the suite from several git worktrees against one local
+  # Postgres, and `db:test:prepare` drops and recreates this database — two runs
+  # finishing at once collide (PG::UniqueViolation on pg_database). PG_TEST_DATABASE
+  # lets each checkout claim its own. Unset (CI, a plain local run) keeps trefle_test.
+  database: <%= ENV['PG_TEST_DATABASE'].to_s.empty? ? 'trefle_test' : ENV['PG_TEST_DATABASE'] %>
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is


### PR DESCRIPTION
Parallel sessions run the suite from several git worktrees against one local Postgres. `db:test:prepare` drops and recreates the test database, so two runs finishing at the same moment race on it and one dies:

```
PG::UniqueViolation: duplicate key value violates unique constraint "pg_database_datname_index"
DETAIL:  Key (datname)=(trefle_test) already exists.
Tasks: TOP => db:test:load_schema => db:test:purge
```

The drop and the create are not atomic together — the second run recreates the database in between the first one's `DROP` and its `CREATE`. Observed today; the same shared-Postgres hazard already showed up once as schema drift leaking between concurrent worktrees.

## Change

- `config/database.yml` reads the test database name from `PG_TEST_DATABASE`.
- `.agents/verify.sh` derives one per worktree from the directory name (lowercased, non-alphanumerics collapsed to `_`, truncated to fit Postgres' 63-byte identifier limit).

Unset — CI, and a plain run in the main checkout — keeps `trefle_test`, so nothing about the existing setup changes. CI passes no such variable, and the main checkout is detected by comparing canonical paths against the git common dir.

`database.yml` uses plain Ruby (`ENV[...].to_s.empty? ? ... : ...`) rather than `.presence`, because the file is parsed early enough that ActiveSupport's core extensions are not guaranteed to be loaded.

## Verification

- Full `verify.sh` in a worktree: RuboCop clean, `1092 examples, 0 failures`, on its own database `trefle_test_fix_test_db_per_worktree`.
- Confirmed the main checkout takes the other branch and stays on `trefle_test`.
- Re-ran after fixing a trailing `_` in the derived name (`basename`'s newline was being folded into the slug by `tr`).

## Known limitation

Per-worktree databases are created but never dropped, so they accumulate as worktrees come and go. They are cheap and empty-ish, but a periodic `DROP DATABASE` sweep over `trefle_test_%` would be worth adding if the count becomes a nuisance. Not done here to keep this change to the race it fixes.

Touches: `config/database.yml`, `.agents/verify.sh`
