### PR TITLE
Bump sidekiq 7.3 to 8.0, redis gem 5 to 6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,19 +65,18 @@ gem 'active_flag'
 # Monitoring
 gem 'pghero'
 gem 'pg_query', '>= 0.9.0'
-gem 'rack-attack', '~> 6.6.1'
+gem 'rack-attack', '~> 6.8'
 
 gem 'sentry-rails', '~> 7.0'
 gem 'sentry-ruby', '~> 7.0'
 gem 'skylight'
 
 # Sidekiq
-gem 'redis', '>= 4.1.4'
+gem 'redis', '~> 6.0'
 gem 'rufus-scheduler', '>= 3.4.2'
-gem 'sidekiq', '~> 7.3'
-gem 'sidekiq-cron', '>= 0.6.3'
+gem 'sidekiq', '~> 8.0'
+gem 'sidekiq-cron', '~> 2.4'
 gem 'sidekiq-limit_fetch'
-gem 'sidekiq-status'
 
 gem 'counter_culture', '~> 2.0'
 gem 'interactor-rails', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,8 +110,6 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    chronic_duration (0.10.6)
-      numerizer (~> 0.1.1)
     coderay (1.1.3)
     colorize (1.1.0)
     concurrent-ruby (1.3.8)
@@ -328,7 +326,6 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.4-x86_64-linux-musl)
       racc (~> 1.4)
-    numerizer (0.1.1)
     oauth2 (2.0.25)
       anonymous_loader (~> 0.1, >= 0.1.3)
       auth-sanitizer (~> 0.2, >= 0.2.3)
@@ -394,21 +391,22 @@ GEM
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)
-    rack (2.2.24)
-    rack-attack (6.6.1)
-      rack (>= 1.0, < 3)
+    rack (3.2.7)
+    rack-attack (6.8.0)
+      rack (>= 1.0, < 4)
     rack-cors (2.0.2)
       rack (>= 2.0.0)
-    rack-protection (3.2.0)
+    rack-protection (4.2.1)
       base64 (>= 0.1.0)
-      rack (~> 2.2, >= 2.2.4)
-    rack-session (1.0.2)
-      rack (< 3)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
+    rack-session (2.1.2)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
     rack-test (2.2.0)
       rack (>= 1.3)
-    rackup (1.0.1)
-      rack (< 3)
-      webrick
+    rackup (2.3.1)
+      rack (>= 3)
     rails (8.0.5.1)
       actioncable (= 8.0.5.1)
       actionmailbox (= 8.0.5.1)
@@ -458,9 +456,9 @@ GEM
       rbs (>= 4.0.0)
       tsort
     recaptcha (5.21.1)
-    redis (5.4.1)
-      redis-client (>= 0.22.0)
-    redis-client (0.27.0)
+    redis (6.0.0)
+      redis-client (= 0.30.1)
+    redis-client (0.30.1)
       connection_pool
     regexp_parser (2.11.3)
     reline (0.7.0)
@@ -550,12 +548,12 @@ GEM
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
       logger
-    sidekiq (7.3.10)
-      base64
-      connection_pool (>= 2.3.0, < 3)
-      logger
-      rack (>= 2.2.4, < 3.3)
-      redis-client (>= 0.23.0, < 1)
+    sidekiq (8.0.10)
+      connection_pool (>= 2.5.0)
+      json (>= 2.9.0)
+      logger (>= 1.6.2)
+      rack (>= 3.1.0)
+      redis-client (>= 0.23.2)
     sidekiq-cron (2.4.0)
       cronex (>= 0.13.0)
       fugit (~> 1.8, >= 1.11.1)
@@ -563,11 +561,6 @@ GEM
       sidekiq (>= 6.5.0)
     sidekiq-limit_fetch (4.4.1)
       sidekiq (>= 6)
-    sidekiq-status (4.0.0)
-      base64
-      chronic_duration
-      logger
-      sidekiq (>= 7, < 9)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -617,7 +610,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.9.2)
     websocket (1.2.11)
     websocket-driver (0.8.2)
       base64
@@ -690,12 +682,12 @@ DEPENDENCIES
   pghero
   pry
   puma
-  rack-attack (~> 6.6.1)
+  rack-attack (~> 6.8)
   rack-cors
   rails (~> 8.0.0)
   rails-controller-testing
   recaptcha
-  redis (>= 4.1.4)
+  redis (~> 6.0)
   rspec
   rspec-rails
   rswag
@@ -707,10 +699,9 @@ DEPENDENCIES
   selenium-webdriver
   sentry-rails (~> 7.0)
   sentry-ruby (~> 7.0)
-  sidekiq (~> 7.3)
-  sidekiq-cron (>= 0.6.3)
+  sidekiq (~> 8.0)
+  sidekiq-cron (~> 2.4)
   sidekiq-limit_fetch
-  sidekiq-status
   simplecov (~> 0.22)
   sitemap_generator
   skylight

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,5 +1,4 @@
 require 'sidekiq'
-require 'sidekiq-status'
 
 Sidekiq.configure_server do |config|
   config.redis = { url: ENV['REDIS_URL'] || 'redis://127.0.0.1:6379' }
@@ -7,17 +6,8 @@ Sidekiq.configure_server do |config|
   schedule_file = 'config/schedule.yml'
 
   Sidekiq::Cron::Job.load_from_hash YAML.load_file(schedule_file) if File.exist?(schedule_file)
-  Sidekiq::Status.configure_client_middleware config, expiration: 30.minutes
-
 end
 
 Sidekiq.configure_client do |config|
   config.redis = { url: ENV['REDIS_URL'] || 'redis://127.0.0.1:6379' }
-
-  # accepts :expiration (optional)
-  Sidekiq::Status.configure_server_middleware config, expiration: 30.minutes
-
-  # accepts :expiration (optional)
-  Sidekiq::Status.configure_client_middleware config, expiration: 30.minutes
-
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,5 @@
 require 'sidekiq/web'
 require 'sidekiq/cron/web'
-require 'sidekiq-status/web'
 
 Rails.application.routes.draw do
 

--- a/spec/requests/web/management_spec.rb
+++ b/spec/requests/web/management_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe 'Management backoffice', type: :request do
     end
 
     %w[species plants users kingdoms subkingdoms divisions division_classes division_orders
-       families genuses record_corrections user_queries species_images foreign_sources data_quality].each do |section|
+       families genuses record_corrections user_queries species_images foreign_sources data_quality
+       sidekiq].each do |section|
       it "refuses non-admin users on /management/#{section}" do
         login_as create(:user), scope: :user
         get "/management/#{section}"
@@ -28,7 +29,8 @@ RSpec.describe 'Management backoffice', type: :request do
     before { login_as create(:admin), scope: :user }
 
     %w[species plants users kingdoms subkingdoms divisions division_classes division_orders
-       families genuses record_corrections user_queries species_images foreign_sources data_quality].each do |section|
+       families genuses record_corrections user_queries species_images foreign_sources data_quality
+       sidekiq].each do |section|
       it "renders /management/#{section}" do
         get "/management/#{section}"
         expect(response).to have_http_status(:ok)


### PR DESCRIPTION
Closes #213

Sidekiq 8 is out; we were on 7.3. This bumps `sidekiq` (~> 7.3 -> ~> 8.0) and `redis` (>= 4.1.4 -> ~> 6.0).

## What moved, and why

- **sidekiq-cron** stays on 2.4 — already compatible with Sidekiq 8, no change needed beyond tightening the Gemfile constraint to `~> 2.4`.
- **rack-attack 6.6.1 -> 6.8** (forced transitive bump, not optional): Sidekiq 8 requires `rack >= 3.1`, and rack-attack 6.6.1 caps rack at `< 3`. `bundle update sidekiq sidekiq-cron redis --conservative` failed to resolve without also bumping rack-attack. This pulls rack 2.2.24 -> 3.2.7 along with it (plus rack-session, rackup, rack-protection). This is a bigger blast radius than the issue anticipated (rack underlies every controller, Devise, OmniAuth), so flagging it explicitly here rather than burying it in the diff. Full RSpec suite, including the CORS and rate-limit-header specs, is green after the bump.
- **sidekiq-status removed**: no worker in the app includes `Sidekiq::Status::Worker`, so its client/server middleware was already a no-op on every real job (verified — the middleware short-circuits unless the worker class ancestors include that module). It's also now actually broken: under the redis-client 0.30 that Sidekiq 8 requires, `Sidekiq::Status::Storage#store_for_id` raises `TypeError: Unsupported command argument type: ActiveSupport::Duration` on the `expiration: 30.minutes` we pass into `configure_client_middleware`/`configure_server_middleware` (reproduced directly against a test worker that includes the mixin). Since it's unused and now broken for its actual purpose, removed it rather than carrying a known-unmaintained, now-broken dependency forward — this also matches this repo's own prior upgrade notes, which already flagged sidekiq-status for removal.
- **sidekiq-limit_fetch** kept as-is: verified its `Sidekiq::Queue#limit`/`#limit=` patch still attaches correctly and functions under Sidekiq 8.0.10 (checked via `bin/rails runner`, both in isolation and inside the app). `config/sidekiq.yml`'s `process_limits:` block is still the mechanism it reads.

## Verification

- Full RSpec suite: 1094 examples, 0 failures (baseline before the bump was also 0 failures).
- RuboCop: 447 files, 0 offenses.
- Brakeman: 0 warnings.
- `bundle exec sidekiq` boots locally and registers all 8 cron jobs from `config/schedule.yml` (verified via `Sidekiq::Cron::Job.all`).
- `/management/sidekiq` (Sidekiq::Web) reachable for an admin, refused for a non-admin — new request specs folded into the existing per-section access-control loop in `spec/requests/web/management_spec.rb`.

Touches: Gemfile, Gemfile.lock, config/initializers/sidekiq.rb, config/routes.rb, spec/requests/web/management_spec.rb