### PR TITLE
Expose species completion_ratio and complete_data publicly

### DIFF
--- a/app/controllers/api/v1/species_controller.rb
+++ b/app/controllers/api/v1/species_controller.rb
@@ -6,6 +6,8 @@ class Api::V1::SpeciesController < Api::ApiController
     author
     bloom_months
     common_name
+    complete_data
+    completion_ratio
     duration
     establishment
     edible
@@ -38,6 +40,8 @@ class Api::V1::SpeciesController < Api::ApiController
     average_height_cm
     bibliography
     common_name
+    complete_data
+    completion_ratio
     edible_part
     family_common_name
     family_name
@@ -91,6 +95,8 @@ class Api::V1::SpeciesController < Api::ApiController
     average_height_cm
     bibliography
     common_name
+    complete_data
+    completion_ratio
     duration
     edible
     family_common_name
@@ -143,6 +149,7 @@ class Api::V1::SpeciesController < Api::ApiController
   RANGEABLE_FIELDS = %w[
     atmospheric_humidity
     average_height_cm
+    completion_ratio
     frost_free_days_minimum
     ground_humidity
     images_count

--- a/app/models/concerns/scopes/species.rb
+++ b/app/models/concerns/scopes/species.rb
@@ -86,6 +86,7 @@ module Scopes
       # Ranges
       scope :range_by_year, ->(a, b) { where(year: ((a&.to_i || -3000)...(b&.to_i || 3000))) }
       scope :range_by_atmospheric_humidity, ->(a, b) { where(atmospheric_humidity: ((a.to_i)...(b&.to_i || 3000))) }
+      scope :range_by_completion_ratio, ->(a, b) { where(completion_ratio: ((a.to_i)...(b&.to_i || 3000))) }
       # scope :range_by_bloom_months, ->(a, b) { where(bloom_months: ((a&.to_i || 0)...(b&.to_i || 3000))) }
       # scope :range_by_duration, ->(a, b) { where(duration: ((a&.to_i || 0)...(b&.to_i || 3000))) }
       scope :range_by_frost_free_days_minimum, ->(a, b) { where(frost_free_days_minimum: ((a.to_i)...(b&.to_i || 3000))) }

--- a/app/serializers/species_light_serializer.rb
+++ b/app/serializers/species_light_serializer.rb
@@ -4,7 +4,8 @@ class SpeciesLightSerializer < BaseSerializer
              :year, :bibliography, :author, :status,
              :rank, :family_common_name, :family,
              :genus_id, :genus,
-             :links, :synonyms, :image_url
+             :links, :synonyms, :image_url,
+             :completion_ratio, :complete_data
 
   def image_url
     object.main_image_url

--- a/app/serializers/species_serializer.rb
+++ b/app/serializers/species_serializer.rb
@@ -147,7 +147,8 @@ class SpeciesSerializer < BaseSerializer
              :distributions, :distribution,
              :duration,
              :links, :image_url,
-             :vegetable, :edible, :edible_part
+             :vegetable, :edible, :edible_part,
+             :completion_ratio, :complete_data
 
   attributes :flower, :foliage,
              :fruit_or_seed, :specifications,

--- a/lib/schemas/v1/species.rb
+++ b/lib/schemas/v1/species.rb
@@ -1,7 +1,7 @@
 module Schemas
   module V1
     module Species # rubocop:todo Metrics/ModuleLength
-      def self.base
+      def self.base # rubocop:todo Metrics/MethodLength
         {
           id: { type: :integer, description: 'An unique identifier' }, # 101131,
           common_name: { type: :string, nullable: true, description: 'The usual common name, in english, of the species (if any).' }, # "grand fir",
@@ -21,6 +21,8 @@ module Schemas
           genus_id: { type: :integer, description: 'The id of the species genus' }, # 101131,
           genus: { type: :string, description: 'The scientific name of the species genus' },
           image_url: { type: :string, nullable: true, description: 'A main image url of the species' },
+          completion_ratio: { type: :integer, nullable: true, description: 'The percentage (0-100) of trait fields filled for this species. Useful for finding species that would benefit from a contribution.' }, # 62,
+          complete_data: { type: :boolean, nullable: true, description: 'Whether this species is considered to have complete data (currently, a completion_ratio above 50%)' }, # true,
           links: Helpers.object_of({
             self: { type: :string, description: 'API endpoint to the species itself' },
             genus: { type: :string, description: 'API endpoint to the species genus' },


### PR DESCRIPTION
Closes #279.

`species.completion_ratio` (integer, 0-100) and `species.complete_data` (boolean) were already computed and kept up to date internally (`Species#update_completion_ratio!`, `Migrators::CompletionWorker`), but never surfaced through the public API.

## Changes
- Added `completion_ratio` and `complete_data` to `SpeciesSerializer` and `SpeciesLightSerializer` — both are plain columns already loaded on the record, so no extra query cost for the light serializer.
- Added both to `FILTERABLE_FIELDS`, `FILTERABLE_NOT_FIELDS`, and `ORDERABLE_FIELDS`; added `completion_ratio` to `RANGEABLE_FIELDS` with a matching `range_by_completion_ratio` scope. `complete_data` is a boolean, so it isn't rangeable (matches the existing convention for other boolean fields like `vegetable`).
- Documented both fields in `lib/schemas/v1/species.rb`. The `filters`/`sorts`/`ranges` swagger schemas derive from the controller's constants, so they update automatically — no separate swagger edit was needed.

## Tests
`filter`/`filter_not`/`order`/`range` coverage for the new fields comes for free from the generic shared examples in `spec/support/shared_examples/collection_endpoints.rb`, which iterate the controller's `FILTERABLE_FIELDS`/`FILTERABLE_NOT_FIELDS`/`ORDERABLE_FIELDS`/`RANGEABLE_FIELDS` constants via `spec/controllers/api/v1/species_controller_spec.rb`.

- `bundle exec rspec spec/controllers/api/v1/species_controller_spec.rb spec/requests/api/v1/3_species_spec.rb` — 223 examples, 0 failures.
- `bundle exec rspec` (full suite) — 1110 examples, 78 failures, all pre-existing on `master` (verified via `git stash`): chromedriver/Capybara, OpenSearch, and env-config (`APP_REVISION`, DOI, FontAwesome kit) related, none touching species/API filtering. Zero new failures introduced.
- `bundle exec rubocop` (full repo) — 0 offenses.

Touches: app/serializers/, app/controllers/api/v1/species_controller.rb, app/models/concerns/scopes/species.rb, lib/schemas/