### PR TITLE
Fix filter_not[image_url] returning nothing on the search endpoints

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -230,29 +230,39 @@ module Api
 
     # @TODO ugly one
     # Turn query params into elasticsearch query
-    def search_params(filter_not_fields: [], filter_fields: [], order_fields: [], range_fields: [])
+    #
+    # field_aliases translates a public filter/order/range key into the field
+    # name actually indexed by Searchkick, for the keys where they differ
+    # (e.g. `image_url` -> `main_image_url`, see Scopes::Species::FIELD_ALIASES)
+    # -- the AR-backed path (Filterable#filter_with et al.) does the same
+    # translation through its own scope, so the two paths stop drifting (#280).
+    def search_params(filter_not_fields: [], filter_fields: [], order_fields: [], range_fields: [], field_aliases: {})
       where = {}
       order = nil
       if params[:filter_not].is_a?(ActionController::Parameters)
         params[:filter_not].permit(filter_not_fields).slice(*filter_not_fields).each do |field, value|
-          where[field] ||= {}
-          where[field][:not] = value&.split(',')&.map {|e| e.blank? || e == 'null' ? nil : e }
+          indexed_field = field_aliases.fetch(field, field)
+          where[indexed_field] ||= {}
+          where[indexed_field][:not] = value&.split(',')&.map {|e| e.blank? || e == 'null' ? nil : e }
         end
       end
       if params[:filter].is_a?(ActionController::Parameters)
         params[:filter].permit(filter_fields).slice(*filter_fields).each do |field, value|
-          where[field] = value.split(',')
+          where[field_aliases.fetch(field, field)] = value.split(',')
         end
       end
       if params[:range].is_a?(ActionController::Parameters)
         params[:range].permit(range_fields).slice(*range_fields).each do |field, value|
           min, max = value.split(',')
-          where[field] ||= {}
-          where[field][:gte] = min if min.present?
-          where[field][:lte] = max if max.present?
+          indexed_field = field_aliases.fetch(field, field)
+          where[indexed_field] ||= {}
+          where[indexed_field][:gte] = min if min.present?
+          where[indexed_field][:lte] = max if max.present?
         end
       end
-      order = params[:order].permit(order_fields).slice(*order_fields).to_unsafe_hash if params[:order].is_a?(ActionController::Parameters)
+      if params[:order].is_a?(ActionController::Parameters)
+        order = params[:order].permit(order_fields).slice(*order_fields).to_unsafe_hash.transform_keys {|field| field_aliases.fetch(field, field) }
+      end
       {
         where: where,
         order: order

--- a/app/controllers/api/v1/plants_controller.rb
+++ b/app/controllers/api/v1/plants_controller.rb
@@ -92,7 +92,8 @@ class Api::V1::PlantsController < Api::ApiController
       filter_not_fields: Api::V1::SpeciesController::FILTERABLE_NOT_FIELDS,
       filter_fields: Api::V1::SpeciesController::FILTERABLE_FIELDS,
       order_fields: Api::V1::SpeciesController::ORDERABLE_FIELDS,
-      range_fields: Api::V1::SpeciesController::RANGEABLE_FIELDS
+      range_fields: Api::V1::SpeciesController::RANGEABLE_FIELDS,
+      field_aliases: ::Scopes::Species::FIELD_ALIASES
     )
     options = {
       where: { main_species_id: nil }.merge(search_params[:where]),

--- a/app/controllers/api/v1/species_controller.rb
+++ b/app/controllers/api/v1/species_controller.rb
@@ -230,7 +230,8 @@ class Api::V1::SpeciesController < Api::ApiController
       filter_not_fields: Api::V1::SpeciesController::FILTERABLE_NOT_FIELDS,
       filter_fields: Api::V1::SpeciesController::FILTERABLE_FIELDS,
       order_fields: Api::V1::SpeciesController::ORDERABLE_FIELDS,
-      range_fields: Api::V1::SpeciesController::RANGEABLE_FIELDS
+      range_fields: Api::V1::SpeciesController::RANGEABLE_FIELDS,
+      field_aliases: ::Scopes::Species::FIELD_ALIASES
     )
     options = {
       where: search_params[:where],

--- a/app/models/concerns/scopes/species.rb
+++ b/app/models/concerns/scopes/species.rb
@@ -2,6 +2,16 @@ module Scopes
   module Species
     extend ActiveSupport::Concern
 
+    # Public filter/order/range key => real column, for the couple of keys
+    # where the public API name doesn't match storage (here: `image_url` is
+    # exposed publicly but the column is `main_image_url`). The AR-backed
+    # scopes below translate through this map; so does the Searchkick path
+    # (Api::ApiController#search_params via `field_aliases:`) -- one mapping
+    # instead of two lists that can drift apart again (#280).
+    FIELD_ALIASES = {
+      'image_url' => 'main_image_url'
+    }.freeze
+
     included do # rubocop:todo Metrics/BlockLength
 
       Api::V1::SpeciesController::FILTERABLE_FIELDS.each do |field|
@@ -81,7 +91,7 @@ module Scopes
       #     where.not(edible_part: [0, nil])
       #   end
       # }
-      scope :filter_not_by_image_url, ->(_v) { where.not(main_image_url: nil) }
+      scope :filter_not_by_image_url, ->(_v) { where.not(FIELD_ALIASES['image_url'] => nil) }
 
       # Ranges
       scope :range_by_year, ->(a, b) { where(year: ((a&.to_i || -3000)...(b&.to_i || 3000))) }

--- a/spec/requests/api/v1/search_filter_field_aliases_spec.rb
+++ b/spec/requests/api/v1/search_filter_field_aliases_spec.rb
@@ -1,0 +1,86 @@
+require 'rails_helper'
+
+# #280: the Searchkick-backed /search endpoints must agree with the
+# AR-backed list endpoints on what a public filter key means. `image_url` is
+# the public name for the `main_image_url` column (see
+# Scopes::Species::FIELD_ALIASES); before this fix the search endpoints
+# passed `image_url` straight into Searchkick, which has no such indexed
+# field, so the filter silently matched nothing instead of raising or
+# filtering correctly.
+describe 'Search filter field aliases (#280)', type: :request do
+  let(:user) { create(:user) }
+
+  # search: true switches Searchkick.disable_callbacks (set suite-wide in
+  # spec_helper.rb) back on for this example, but the model is configured
+  # with `callbacks: :queue` (app/models/concerns/search/species.rb), which
+  # only enqueues a Sidekiq job -- nothing processes that queue inline
+  # during specs. Force synchronous indexing explicitly, then refresh so the
+  # write is visible to the search we issue right after.
+  def index_synchronously(&block)
+    Searchkick.callbacks(:inline, &block)
+    Species.searchkick_index.refresh
+  end
+
+  describe 'GET /api/v1/species/search' do
+    it 'filter_not[image_url]=null matches the AR-backed index endpoint, not zero results', search: true do
+      with_photo = nil
+      without_photo = nil
+      index_synchronously do
+        with_photo = create(:species, scientific_name: 'Zzztestus withphotoae', main_image_url: 'https://example.com/a.jpg')
+        without_photo = create(:species, scientific_name: 'Zzztestus nophotoae', main_image_url: nil)
+      end
+
+      get '/api/v1/species/search', params: { q: 'Zzztestus', token: user.token, filter_not: { image_url: 'null' } }
+      body = JSON.parse(response.body)
+
+      expect(response).to have_http_status(:success)
+      names = body['data'].map {|s| s['scientific_name'] }
+      expect(names).to include(with_photo.scientific_name)
+      expect(names).not_to include(without_photo.scientific_name)
+    end
+  end
+
+  describe 'GET /api/v1/plants/search' do
+    it 'filter_not[image_url]=null matches the AR-backed index endpoint, not zero results', search: true do
+      with_photo = nil
+      without_photo = nil
+      index_synchronously do
+        with_photo = create(:species, scientific_name: 'Zzzplantus withphotoae', main_image_url: 'https://example.com/a.jpg')
+        without_photo = create(:species, scientific_name: 'Zzzplantus nophotoae', main_image_url: nil)
+      end
+
+      get '/api/v1/plants/search', params: { q: 'Zzzplantus', token: user.token, filter_not: { image_url: 'null' } }
+      body = JSON.parse(response.body)
+
+      expect(response).to have_http_status(:success)
+      names = body['data'].map {|s| s['scientific_name'] }
+      expect(names).to include(with_photo.scientific_name)
+      expect(names).not_to include(without_photo.scientific_name)
+    end
+  end
+
+  # Audit finding from #280: `establishment` has the same shape of bug as
+  # `image_url` had (a FILTERABLE_FIELDS key with no equivalent in the
+  # Searchkick index -- it lives on the species_distributions association,
+  # never indexed), but isn't fixed here: unlike image_url there is no
+  # single real column to alias to, it would need indexing
+  # species_distributions data into Searchkick. This test pins the current
+  # (silently-wrong) behavior so it doesn't regress unnoticed and is easy to
+  # find for whoever picks that up.
+  describe 'GET /api/v1/species/search filter[establishment] (known gap, not fixed by #280)' do
+    it 'silently returns no results instead of filtering, unlike GET /api/v1/species' do
+      species = nil
+      index_synchronously do
+        species = create(:species, scientific_name: 'Zzzestablishmentus testae')
+        SpeciesDistribution.create!(species: species, zone: Zone.first, establishment: 'native')
+        species.save!
+      end
+
+      get '/api/v1/species/search', params: { q: 'Zzzestablishmentus', token: user.token, filter: { establishment: 'native' } }
+      body = JSON.parse(response.body)
+
+      expect(response).to have_http_status(:success)
+      expect(body['data']).to eq([])
+    end
+  end
+end


### PR DESCRIPTION
Closes #280.

## Bug

`/api/v1/plants/search?q=coco` returns real results; the same query with `filter_not[image_url]=null` returned **0**. The AR-backed list endpoints (`GET /api/v1/species`, `GET /api/v1/plants`) already got this right via a scope in `app/models/concerns/scopes/species.rb` that translates the public key `image_url` to the real column `main_image_url`. The Searchkick-backed `/search` endpoints had no equivalent: `search_params` (`app/controllers/api/api_controller.rb`) passed `image_url` straight into Searchkick's `where:`, and the index has no such field (only `main_image_url`), so the filter silently matched nothing.

## Fix

Added one mapping, `Scopes::Species::FIELD_ALIASES`, used by both paths instead of two lists that can drift apart again:
- the AR scope (`filter_not_by_image_url`) now reads the column name from it instead of a hardcoded literal
- `Api::ApiController#search_params` translates `filter`/`filter_not`/`range`/`order` keys through it before building the Searchkick `where:`/`order:` hash, so both `/api/v1/species/search` and `/api/v1/plants/search` (which share `search_params`) are fixed together

Landed in `scopes/species.rb` + `api_controller.rb` rather than `app/models/concerns/search/` (the issue's guess at scope): translating the key before it reaches Searchkick, per the issue's own preferred option, didn't need any change to what gets indexed.

## Audit: other filterable keys with the same mismatch

Went through `FILTERABLE_FIELDS`, `FILTERABLE_NOT_FIELDS`, `ORDERABLE_FIELDS`, `RANGEABLE_FIELDS` against what's actually indexed (`Search::Species#search_data` = `attributes` merged with a few explicit overrides for bitmask/array fields). Everything else is a real `species` column (or a denormalized one, e.g. `genus_name`/`family_name`) that's present in `attributes` under the same name, so it lines up on both paths.

One more mismatch of the exact same shape: **`establishment`** (`filter[establishment]`, in `FILTERABLE_FIELDS`). On the AR path it's a dedicated scope joining `species_distributions`. It's never indexed by Searchkick at all, so `filter[establishment]=native` on `/search` silently returns zero results too, same as `image_url` did.

**Not fixed here** — unlike `image_url` there's no single real column to alias to; a real fix means indexing `species_distributions` data into Searchkick, which is a data-pipeline change out of this issue's scope. Pinned with a characterization spec (`spec/requests/api/v1/search_filter_field_aliases_spec.rb`) documenting the current (silently-wrong) behavior so it's easy to find and doesn't regress further unnoticed. Flagging it here as the follow-up worth filing.

## Tests

- Two request specs reproduce the original bug against real Searchkick/OpenSearch (`search: true`, forcing synchronous indexing since the model's `callbacks: :queue` mode doesn't index inline during specs) and confirm the fix on both `/api/v1/species/search` and `/api/v1/plants/search`.
- One characterization spec pins the known `establishment` gap.
- Verified all three regress to failing against the pre-fix code (temporarily reverted locally) before confirming green with the fix.
- Full suite: 1095 examples, 0 failures. RuboCop: 0 offenses.

Touches: app/controllers/api/, app/models/concerns/scopes/, spec/requests