### PR TITLE
Journal every data run in the database it changed

### DIFF
--- a/app/controllers/management/data_runs_controller.rb
+++ b/app/controllers/management/data_runs_controller.rb
@@ -1,0 +1,14 @@
+# Journal of the data operations run against this database (DataRun):
+# imports, purges, migrations — including one-off runs from outside the
+# cluster. Read-only: the rows are written by the runs themselves.
+class Management::DataRunsController < Management::ManagementController
+
+  def index
+    @runs = DataRun.recent.limit(200)
+  end
+
+  def show
+    @run = DataRun.find(params[:id])
+  end
+
+end

--- a/app/models/data_run.rb
+++ b/app/models/data_run.rb
@@ -1,0 +1,90 @@
+require 'socket'
+
+# One row per data operation run against this database: imports, purges,
+# migrations, crawls. The journal lives in the database on purpose — pod
+# logs rotate, and one-off runs (a laptop port-forwarded onto production)
+# leave no trace anywhere else.
+#
+#   DataRun.track!(runnable: self.class.name, kind: 'import',
+#                  arguments: { paths: paths }, dry_run: dry_run) do |run|
+#     stats = do_the_work
+#     stats # a Hash return value becomes the stored report
+#   end
+#
+# Every tracked run measures the dataset's key counters before and after,
+# so the impact is recorded as observed deltas rather than claimed ones.
+# Failures are recorded (status, error, partial impact) and re-raised.
+class DataRun < ApplicationRecord
+
+  enum :status, { running: 0, completed: 1, failed: 2 }, suffix: true
+
+  validates :runnable, :kind, presence: true
+
+  scope :recent, -> { order(started_at: :desc) }
+
+  # Cheap enough to run twice per tracked run, wide enough that a run
+  # touching anything structural shows up.
+  IMPACT_COUNTERS = {
+    'species' => -> { Species.count },
+    'plants' => -> { Plant.count },
+    'synonyms' => -> { Synonym.count },
+    'species_facts' => -> { SpeciesFact.count },
+    'active_facts' => -> { SpeciesFact.active_status.count },
+    'common_names' => -> { CommonName.count },
+    'species_images' => -> { SpeciesImage.count },
+    'species_distributions' => -> { SpeciesDistribution.count },
+    'foreign_sources_plants' => -> { ForeignSourcesPlant.count }
+  }.freeze
+
+  def self.track!(runnable:, kind:, arguments: {}, dry_run: false)
+    run = create!(
+      runnable: runnable, kind: kind, arguments: arguments, dry_run: dry_run,
+      started_at: Time.zone.now, host: Socket.gethostname,
+      revision: ENV.fetch('APP_REVISION', nil)
+    )
+    before = capture_counters
+
+    begin
+      result = yield run
+      run.update!(
+        status: :completed, finished_at: Time.zone.now,
+        report: result.is_a?(Hash) ? result : run.report,
+        impact: impact_between(before, capture_counters)
+      )
+      result
+    rescue Exception => e # rubocop:disable Lint/RescueException
+      # Even a SystemStackError deserves a journal entry (one killed a purge
+      # run once); the failure is recorded with its partial impact, then
+      # re-raised untouched.
+      run.update!(
+        status: :failed, finished_at: Time.zone.now,
+        error: "#{e.class}: #{e.message.to_s[0, 500]}",
+        impact: impact_between(before, capture_counters)
+      )
+      raise
+    end
+  end
+
+  def self.capture_counters
+    IMPACT_COUNTERS.transform_values(&:call)
+  end
+
+  def self.impact_between(before, after)
+    before.to_h do |name, was|
+      now = after[name]
+      [name, { 'before' => was, 'after' => now, 'delta' => now - was }]
+    end
+  end
+
+  def duration
+    return nil unless finished_at && started_at
+
+    finished_at - started_at
+  end
+
+  # The deltas worth showing on a list row.
+  def moved_counters
+    impact.select {|_name, values| values['delta']&.nonzero? }
+  end
+
+end

--- a/app/views/management/data_runs/index.html.erb
+++ b/app/views/management/data_runs/index.html.erb
@@ -1,0 +1,50 @@
+<h1 class="title">Data runs</h1>
+<p class="subtitle is-6">
+  Journal of the operations that shaped the dataset — imports, purges,
+  migrations — wherever they ran from. Impacts are measured deltas, not claims.
+</p>
+
+<% if @runs.empty? %>
+  <div class="notification is-info">
+    No run recorded yet. Runs journal themselves through <code>DataRun.track!</code>.
+  </div>
+<% else %>
+  <table class="table is-fullwidth is-striped is-narrow">
+    <thead>
+      <tr>
+        <th>Started</th>
+        <th>Run</th>
+        <th>Kind</th>
+        <th>Where</th>
+        <th>Status</th>
+        <th>Duration</th>
+        <th>Impact</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @runs.each do |run| %>
+        <tr>
+          <td><%= run.started_at.strftime('%Y-%m-%d %H:%M') %></td>
+          <td>
+            <%= link_to(run.runnable, management_data_run_path(run)) %>
+            <% if run.dry_run? %><span class="tag is-light">dry run</span><% end %>
+          </td>
+          <td><%= run.kind %></td>
+          <td><code><%= run.host %></code></td>
+          <td>
+            <% status_class = { 'running' => 'is-info', 'completed' => 'is-success', 'failed' => 'is-danger' }[run.status] %>
+            <span class="tag <%= status_class %>"><%= run.status %></span>
+          </td>
+          <td><%= run.duration ? "#{run.duration.round}s" : '—' %></td>
+          <td>
+            <% run.moved_counters.first(4).each do |name, values| %>
+              <span class="tag is-light">
+                <%= name %>&nbsp;<strong><%= values['delta'].positive? ? '+' : '' %><%= number_with_delimiter(values['delta']) %></strong>
+              </span>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/app/views/management/data_runs/show.html.erb
+++ b/app/views/management/data_runs/show.html.erb
@@ -1,0 +1,73 @@
+<h1 class="title"><%= @run.runnable %></h1>
+<p class="subtitle is-6">
+  <%= @run.kind %> ·
+  started <%= @run.started_at.strftime('%Y-%m-%d %H:%M:%S') %>
+  on <code><%= @run.host %></code>
+  <% if @run.revision.present? %> · revision <code><%= @run.revision %></code><% end %>
+  <% if @run.dry_run? %> · <span class="tag is-light">dry run</span><% end %>
+</p>
+
+<div class="columns">
+  <div class="column">
+    <div class="box has-text-centered">
+      <p class="heading">Status</p>
+      <p class="title is-4"><%= @run.status %></p>
+    </div>
+  </div>
+  <div class="column">
+    <div class="box has-text-centered">
+      <p class="heading">Duration</p>
+      <p class="title is-4"><%= @run.duration ? "#{@run.duration.round}s" : '—' %></p>
+    </div>
+  </div>
+  <div class="column">
+    <div class="box has-text-centered">
+      <p class="heading">Counters moved</p>
+      <p class="title is-4"><%= @run.moved_counters.size %></p>
+    </div>
+  </div>
+</div>
+
+<% if @run.error.present? %>
+  <div class="notification is-danger"><code><%= @run.error %></code></div>
+<% end %>
+
+<% if @run.arguments.present? %>
+  <h2 class="title is-5">Arguments</h2>
+  <pre><%= JSON.pretty_generate(@run.arguments) %></pre>
+<% end %>
+
+<h2 class="title is-5">Impact (measured before / after)</h2>
+<% if @run.impact.blank? %>
+  <p>No impact captured.</p>
+<% else %>
+  <table class="table is-narrow is-striped">
+    <thead><tr><th>Counter</th><th>Before</th><th>After</th><th>Delta</th></tr></thead>
+    <tbody>
+      <% @run.impact.each do |name, values| %>
+        <tr class="<%= values['delta']&.nonzero? ? '' : 'has-text-grey-light' %>">
+          <td><%= name %></td>
+          <td><%= number_with_delimiter(values['before']) %></td>
+          <td><%= number_with_delimiter(values['after']) %></td>
+          <td><strong><%= values['delta'].positive? ? '+' : '' %><%= number_with_delimiter(values['delta']) %></strong></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>
+
+<h2 class="title is-5">Report</h2>
+<% if @run.report.blank? %>
+  <p>No report attached.</p>
+<% else %>
+  <table class="table is-narrow is-striped">
+    <tbody>
+      <% @run.report.sort_by {|k, _| k.to_s }.each do |key, value| %>
+        <tr>
+          <td><%= key %></td>
+          <td><%= value.is_a?(Numeric) ? number_with_delimiter(value) : value %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/app/views/management/layouts/_header.html.erb
+++ b/app/views/management/layouts/_header.html.erb
@@ -22,6 +22,7 @@
       <% end %>
       <%= link_to('Chaos', chaos_management_species_images_path, class: 'navbar-item') %>
       <%= link_to('Data quality', management_data_quality_path, class: 'navbar-item') %>
+      <%= link_to('Data runs', management_data_runs_path, class: 'navbar-item') %>
       <%= link_to('Queries', management_user_queries_path, class: 'navbar-item') %>
       <%= link_to('Stats', stats_management_user_queries_path, class: 'navbar-item') %>
       <%= link_to('Users', management_users_path, class: 'navbar-item') %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,6 +87,7 @@ Rails.application.routes.draw do
 
     get '/', to: 'plants#index'
     get '/data_quality', to: 'data_quality#index'
+    resources :data_runs, only: %i[index show]
 
     resources :users
     resources :user_queries do

--- a/db/migrate/20260908150000_create_data_runs.rb
+++ b/db/migrate/20260908150000_create_data_runs.rb
@@ -1,0 +1,28 @@
+class CreateDataRuns < ActiveRecord::Migration[8.0]
+  def change
+    # Durable journal of the data operations that shape the dataset —
+    # imports, purges, migrations, crawls — wherever they run from: the
+    # sidekiq pods and one-off runs against the production database (e.g.
+    # through a port-forward) all write here, so the trace survives pod log
+    # rotation and lives next to the data it changed.
+    create_table :data_runs do |t|
+      t.string :runnable, null: false
+      t.string :kind, null: false
+      t.jsonb :arguments, default: {}, null: false
+      t.boolean :dry_run, default: false, null: false
+      t.integer :status, default: 0, null: false
+      t.jsonb :report, default: {}, null: false
+      t.jsonb :impact, default: {}, null: false
+      t.string :host
+      t.string :revision
+      t.text :error
+      t.datetime :started_at, null: false
+      t.datetime :finished_at
+
+      t.timestamps
+    end
+
+    add_index :data_runs, :started_at
+    add_index :data_runs, %i[runnable started_at]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_09_07_110000) do
+ActiveRecord::Schema[8.0].define(version: 2026_09_08_150000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -38,6 +38,25 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_07_110000) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["snapshot_on", "dimension", "dimension_value", "attribute_name"], name: "idx_quality_snapshots_unique", unique: true
+  end
+
+  create_table "data_runs", force: :cascade do |t|
+    t.string "runnable", null: false
+    t.string "kind", null: false
+    t.jsonb "arguments", default: {}, null: false
+    t.boolean "dry_run", default: false, null: false
+    t.integer "status", default: 0, null: false
+    t.jsonb "report", default: {}, null: false
+    t.jsonb "impact", default: {}, null: false
+    t.string "host"
+    t.string "revision"
+    t.text "error"
+    t.datetime "started_at", null: false
+    t.datetime "finished_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["runnable", "started_at"], name: "index_data_runs_on_runnable_and_started_at"
+    t.index ["started_at"], name: "index_data_runs_on_started_at"
   end
 
   create_table "division_classes", force: :cascade do |t|

--- a/spec/models/data_run_spec.rb
+++ b/spec/models/data_run_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe DataRun do
+
+  describe '.track!' do
+    it 'journals a successful run with its report and measured impact' do
+      result = described_class.track!(runnable: 'Import::Demo', kind: 'import',
+                                      arguments: { path: 'x.txt' }) do
+        create(:species)
+        { rows: 42 }
+      end
+
+      expect(result).to eq({ rows: 42 })
+      run = described_class.sole
+      expect(run).to be_completed_status
+      expect(run.report).to eq({ 'rows' => 42 })
+      expect(run.arguments).to eq({ 'path' => 'x.txt' })
+      expect(run.impact.dig('species', 'delta')).to eq(1)
+      expect(run.host).to be_present
+      expect(run.duration).to be >= 0
+    end
+
+    it 'journals a failure with its partial impact, then re-raises' do
+      expect do
+        described_class.track!(runnable: 'Import::Demo', kind: 'import') do
+          create(:species)
+          raise ArgumentError, 'boom'
+        end
+      end.to raise_error(ArgumentError, 'boom')
+
+      run = described_class.sole
+      expect(run).to be_failed_status
+      expect(run.error).to include('ArgumentError: boom')
+      expect(run.impact.dig('species', 'delta')).to eq(1)
+      expect(run.finished_at).to be_present
+    end
+
+    it 'flags dry runs and records zero deltas for them' do
+      described_class.track!(runnable: 'Import::Demo', kind: 'import', dry_run: true) { { seen: 3 } }
+
+      run = described_class.sole
+      expect(run).to be_dry_run
+      expect(run.moved_counters).to be_empty
+    end
+  end
+
+end

--- a/spec/requests/web/management_spec.rb
+++ b/spec/requests/web/management_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe 'Management backoffice', type: :request do
     end
 
     %w[species plants users kingdoms subkingdoms divisions division_classes division_orders
-       families genuses record_corrections user_queries species_images foreign_sources data_quality].each do |section|
+       families genuses record_corrections user_queries species_images foreign_sources data_quality
+       data_runs].each do |section|
       it "refuses non-admin users on /management/#{section}" do
         login_as create(:user), scope: :user
         get "/management/#{section}"
@@ -28,7 +29,8 @@ RSpec.describe 'Management backoffice', type: :request do
     before { login_as create(:admin), scope: :user }
 
     %w[species plants users kingdoms subkingdoms divisions division_classes division_orders
-       families genuses record_corrections user_queries species_images foreign_sources data_quality].each do |section|
+       families genuses record_corrections user_queries species_images foreign_sources data_quality
+       data_runs].each do |section|
       it "renders /management/#{section}" do
         get "/management/#{section}"
         expect(response).to have_http_status(:ok)


### PR DESCRIPTION
A durable journal of the operations that shape the dataset — imports, purges, migrations, crawls — written **by the runs themselves into the database they change**. Pod logs rotate (the synonym-purge journal nearly vanished with them), and one-off runs against production through a port-forward leave no trace anywhere else; this gives both a home.

- `DataRun.track!(runnable:, kind:, arguments:, dry_run:) { ... }`: journals start/end, host, `APP_REVISION`, the run's own stats hash as its report, and the **measured impact** — nine dataset counters (species, plants, synonyms, facts, images, distributions, common names, source links) captured before and after, stored as deltas. Failures are recorded with their partial impact and re-raised, `Exception` included (a `SystemStackError` once killed a purge run with no trace).
- Read-only `/management/data_runs` (list + detail, Bulma like data_quality) — status, duration, where it ran, which counters moved.
- Additive migration; the private pipeline's workers adopt `DataRun.track!` next (defensively, so older images keep working).

Suite: 1097 examples, 0 failures; RuboCop and Brakeman clean.