### PR TITLE
Management: fix unnamespaced route helpers and friendly_id lookups on show pages

### DIFF
--- a/app/controllers/management/division_classes_controller.rb
+++ b/app/controllers/management/division_classes_controller.rb
@@ -63,7 +63,7 @@ class Management::DivisionClassesController < Management::ManagementController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_division_class
-    @division_class = DivisionClass.find(params[:id])
+    @division_class = DivisionClass.friendly.find(params[:id])
   end
 
   # Never trust parameters from the scary internet, only allow the white list through.

--- a/app/controllers/management/division_orders_controller.rb
+++ b/app/controllers/management/division_orders_controller.rb
@@ -63,7 +63,7 @@ class Management::DivisionOrdersController < Management::ManagementController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_division_order
-    @division_order = DivisionOrder.find(params[:id])
+    @division_order = DivisionOrder.friendly.find(params[:id])
   end
 
   # Never trust parameters from the scary internet, only allow the white list through.

--- a/app/controllers/management/divisions_controller.rb
+++ b/app/controllers/management/divisions_controller.rb
@@ -63,7 +63,7 @@ class Management::DivisionsController < Management::ManagementController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_division
-    @division = Division.find(params[:id])
+    @division = Division.friendly.find(params[:id])
   end
 
   # Never trust parameters from the scary internet, only allow the white list through.

--- a/app/controllers/management/families_controller.rb
+++ b/app/controllers/management/families_controller.rb
@@ -63,7 +63,7 @@ class Management::FamiliesController < Management::ManagementController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_family
-    @family = Family.find(params[:id])
+    @family = Family.friendly.find(params[:id])
   end
 
   # Never trust parameters from the scary internet, only allow the white list through.

--- a/app/controllers/management/foreign_sources_controller.rb
+++ b/app/controllers/management/foreign_sources_controller.rb
@@ -64,7 +64,7 @@ class Management::ForeignSourcesController < Management::ManagementController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_foreign_source
-    @foreign_source = ForeignSource.find(params[:id])
+    @foreign_source = ForeignSource.friendly.find(params[:id])
   end
 
   # Never trust parameters from the scary internet, only allow the white list through.

--- a/app/controllers/management/kingdoms_controller.rb
+++ b/app/controllers/management/kingdoms_controller.rb
@@ -63,7 +63,7 @@ class Management::KingdomsController < Management::ManagementController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_kingdom
-    @kingdom = Kingdom.find(params[:id])
+    @kingdom = Kingdom.friendly.find(params[:id])
   end
 
   # Never trust parameters from the scary internet, only allow the white list through.

--- a/app/controllers/management/subkingdoms_controller.rb
+++ b/app/controllers/management/subkingdoms_controller.rb
@@ -63,7 +63,7 @@ class Management::SubkingdomsController < Management::ManagementController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_subkingdom
-    @subkingdom = Subkingdom.find(params[:id])
+    @subkingdom = Subkingdom.friendly.find(params[:id])
   end
 
   # Never trust parameters from the scary internet, only allow the white list through.

--- a/app/views/management/division_classes/show.html.erb
+++ b/app/views/management/division_classes/show.html.erb
@@ -21,4 +21,4 @@
 </p>
 
 <%= link_to 'Edit', edit_management_division_class_path(@division_class) %> |
-<%= link_to 'Back', division_classes_path %>
+<%= link_to 'Back', management_division_classes_path %>

--- a/app/views/management/division_orders/show.html.erb
+++ b/app/views/management/division_orders/show.html.erb
@@ -21,4 +21,4 @@
 </p>
 
 <%= link_to 'Edit', edit_management_division_order_path(@division_order) %> |
-<%= link_to 'Back', division_orders_path %>
+<%= link_to 'Back', management_division_orders_path %>

--- a/app/views/management/divisions/show.html.erb
+++ b/app/views/management/divisions/show.html.erb
@@ -21,4 +21,4 @@
 </p>
 
 <%= link_to 'Edit', edit_management_division_path(@division) %> |
-<%= link_to 'Back', divisions_path %>
+<%= link_to 'Back', management_divisions_path %>

--- a/app/views/management/families/show.html.erb
+++ b/app/views/management/families/show.html.erb
@@ -31,4 +31,4 @@
 </p>
 
 <%= link_to 'Edit', edit_management_family_path(@family) %> |
-<%= link_to 'Back', families_path %>
+<%= link_to 'Back', management_families_path %>

--- a/app/views/management/foreign_sources/show.html.erb
+++ b/app/views/management/foreign_sources/show.html.erb
@@ -21,4 +21,4 @@
 </p>
 
 <%= link_to 'Edit', edit_management_foreign_source_path(@foreign_source) %> |
-<%= link_to 'Back', foreign_sources_path %>
+<%= link_to 'Back', management_foreign_sources_path %>

--- a/app/views/management/foreign_sources_plants/show.html.erb
+++ b/app/views/management/foreign_sources_plants/show.html.erb
@@ -26,4 +26,4 @@
 </p>
 
 <%= link_to 'Edit', edit_management_foreign_sources_plant_path(@foreign_sources_plant) %> |
-<%= link_to 'Back', foreign_sources_plants_path %>
+<%= link_to 'Back', management_foreign_sources_plants_path %>

--- a/app/views/management/kingdoms/show.html.erb
+++ b/app/views/management/kingdoms/show.html.erb
@@ -16,4 +16,4 @@
 </p>
 
 <%= link_to 'Edit', edit_management_kingdom_path(@kingdom) %> |
-<%= link_to 'Back', kingdoms_path %>
+<%= link_to 'Back', management_kingdoms_path %>

--- a/app/views/management/major_groups/show.html.erb
+++ b/app/views/management/major_groups/show.html.erb
@@ -16,4 +16,4 @@
 </p>
 
 <%= link_to 'Edit', edit_management_major_group_path(@major_group) %> |
-<%= link_to 'Back', major_groups_path %>
+<%= link_to 'Back', management_major_groups_path %>

--- a/app/views/management/sessions/show.html.erb
+++ b/app/views/management/sessions/show.html.erb
@@ -25,5 +25,5 @@
   <%= @session.inserted_at %>
 </p>
 
-<%= link_to 'Edit', edit_session_path(@session) %> |
-<%= link_to 'Back', sessions_path %>
+<%= link_to 'Edit', edit_management_session_path(@session) %> |
+<%= link_to 'Back', management_sessions_path %>

--- a/app/views/management/species_images/show.html.erb
+++ b/app/views/management/species_images/show.html.erb
@@ -16,4 +16,4 @@
 </p>
 
 <%= link_to 'Edit', edit_management_species_image_path(@species_image) %> |
-<%= link_to 'Back', species_images_path %>
+<%= link_to 'Back', management_species_images_path %>

--- a/app/views/management/species_proposals/show.html.erb
+++ b/app/views/management/species_proposals/show.html.erb
@@ -515,5 +515,5 @@
   <%= @species_proposal.synonym_of %>
 </p>
 
-<%= link_to 'Edit', edit_species_proposal_path(@species_proposal) %> |
-<%= link_to 'Back', species_proposals_path %>
+<%= link_to 'Edit', edit_management_species_proposal_path(@species_proposal) %> |
+<%= link_to 'Back', management_species_proposals_path %>

--- a/app/views/management/subkingdoms/show.html.erb
+++ b/app/views/management/subkingdoms/show.html.erb
@@ -21,4 +21,4 @@
 </p>
 
 <%= link_to 'Edit', edit_management_subkingdom_path(@subkingdom) %> |
-<%= link_to 'Back', subkingdoms_path %>
+<%= link_to 'Back', management_subkingdoms_path %>

--- a/spec/requests/management/families_spec.rb
+++ b/spec/requests/management/families_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe 'Management::Families', type: :request do
+  before { login_as create(:admin), scope: :user }
+
+  describe 'GET /management/families' do
+    it 'renders 200' do
+      get management_families_path
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'GET /management/families/:id' do
+    it 'renders 200' do
+      family = create(:family)
+
+      get management_family_path(family)
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'links back to the families index' do
+      family = create(:family)
+
+      get management_family_path(family)
+
+      expect(response.body).to include(management_families_path)
+    end
+  end
+end

--- a/spec/requests/management/friendly_id_show_pages_spec.rb
+++ b/spec/requests/management/friendly_id_show_pages_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+# The families show-page fix (see families_spec.rb) surfaced a related bug on
+# every other slugged taxonomy resource in the back-office: their controllers
+# looked records up with `Model.find(params[:id])`, but every link generated
+# from a view (index's "Show"/"Edit", show's "Edit") passes the FriendlyId
+# slug, not the numeric id, via `to_param`. `Model.find(<slug>)` raises
+# ActiveRecord::RecordNotFound, so the page was unreachable by clicking
+# through the UI even though it happened to work when the numeric id was
+# typed into the URL directly. Fixed by switching those controllers to
+# `Model.friendly.find`, matching the pattern already used by
+# genuses/plants/species.
+RSpec.describe 'Management show pages reachable via their own slug', type: :request do
+  before { login_as create(:admin), scope: :user }
+
+  # Records come from the seeded taxonomy tree (db/botanic_seeds.rb) rather
+  # than FactoryBot: those tables are seeded with hardcoded ids and no
+  # sequence bump (a pre-existing gap, same as the foreign_sources_id_seq
+  # setval already worked around in rails_helper.rb), so freshly-factoried
+  # rows can collide with them on id. Reading an existing seeded row sidesteps
+  # that without touching unrelated infrastructure.
+  {
+    division: -> { Division.first },
+    division_class: -> { DivisionClass.first },
+    division_order: -> { DivisionOrder.first },
+    foreign_source: -> { ForeignSource.first },
+    kingdom: -> { Kingdom.first },
+    subkingdom: -> { Subkingdom.first }
+  }.each do |resource, record|
+    it "renders /management/#{resource.to_s.pluralize}/:slug" do
+      path_helper = "management_#{resource}_path"
+      get send(path_helper, record.call)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end


### PR DESCRIPTION
Closes #332

## What was broken

`app/views/management/families/show.html.erb` called `families_path`, which doesn't exist at the top level — `resources :families` is only declared inside the `api/v1` and `management` namespaces (giving `api_v1_families_path` / `management_families_path`). Visiting `/management/families/:id` raised `NoMethodError` on render (Sentry API-86).

## Fix

- `families_path` → `management_families_path` in the families show view.
- Audited every other `management/*` show view for the same scaffold mistake (per the issue's acceptance criteria) and found the identical bug in 11 more: `division_classes`, `division_orders`, `divisions`, `foreign_sources`, `foreign_sources_plants`, `kingdoms`, `major_groups`, `sessions`, `species_images`, `species_proposals`, `subkingdoms`. Fixed all of them the same way. `genuses`, `plants`, `species` and `users` show views already used correctly namespaced helpers.

## Related bug found while fixing

Fixing the families route helper wasn't enough on its own to make the page reachable via normal navigation: `Family` (and 6 other resources — `divisions`, `division_classes`, `division_orders`, `foreign_sources`, `kingdoms`, `subkingdoms`) use FriendlyId slugged, but their controllers looked records up with `Model.find(params[:id])`. Every view link (`link_to 'Show', [:management, family]`, `edit_management_family_path(family)`, ...) passes the slug via `to_param`, not the numeric id, so `Model.find(<slug>)` raised `ActiveRecord::RecordNotFound` — the show/edit pages stayed unreachable by clicking through the UI even after the route helper fix, only "working" if you hand-typed the numeric id in the URL (as the original Sentry report did). Switched those 7 controllers to `Model.friendly.find(params[:id])`, matching the pattern already used by the (untouched) `genuses`/`plants`/`species` controllers. I judged this necessary rather than out-of-scope: acceptance criterion 1 ("GET /management/families/:id renders 200 for an admin") only holds via the actual Show link with this fix in place.

## Tests

Added `spec/requests/management/` (didn't exist before):
- `families_spec.rb` — covers `management/families#index` and `#show`, per the acceptance criteria.
- `friendly_id_show_pages_spec.rb` — covers the friendly_id lookup fix on the other 6 affected resources.

Full suite green (1101 examples, 0 failures), rubocop clean.

## Found but deliberately not fixed here — recommend a follow-up issue

Most `management/*` CRUD controllers' `create`/`update`/`destroy` actions use bare `redirect_to @model` / `redirect_to model_url` (e.g. `redirect_to @genuse`, `redirect_to families_url`). This raises the same kind of `NoMethodError` as the bug this issue is about, because Rails doesn't auto-namespace polymorphic redirects — confirmed by reproducing it against `genuses#create` (`undefined method 'genus_url'`). Affects roughly a dozen controllers (families, divisions, division_classes, division_orders, foreign_sources, foreign_sources_plants, genuses, kingdoms, major_groups, plants, subkingdoms, species_images, users) — i.e. creating, editing or deleting most back-office records is currently broken. `species_controller` is the only one that already does this right (`redirect_to [:management, @species]`). This is a write-path bug across many controllers and deserves its own issue rather than riding along with this show-page fix.

Touches: app/views/management/, app/controllers/management/, spec/requests/management/