### PR TITLE
Donate: stop promising an upgrade within an hour, and drop the bold in the sponsor section

### DIFF
--- a/app/views/home/donate.html.erb
+++ b/app/views/home/donate.html.erb
@@ -47,14 +47,13 @@
         <h1 class="title is-4 ">
           <%= fa_icon('hand-heart', class: 'has-text-success') %> How to sponsor us
         </h1>
-        <p><b>Sponsors have an extended request limit of 600 requests/minute.</b></p>
-        <p>To do this, you need to
-          <ol>
-            <li><a href="<%= profile_path %>" target="_blank">Link your account to Github</a></li>
-            <li><a href="https://github.com/sponsors/treflehq" target="_blank">Sponsor us on Github</a>.</li>
-          </ol>
-        </p>
-        <p>Your account will then be upgraded within an hour, and your API token will change.</p>
+        <p>Sponsors have an extended request limit of 600 requests/minute.</p>
+        <p>To do this, you need to:</p>
+        <ol>
+          <li><a href="<%= profile_path %>" target="_blank">Link your account to Github</a></li>
+          <li><a href="https://github.com/sponsors/treflehq" target="_blank">Sponsor us on Github</a>.</li>
+        </ol>
+        <p>Your account will then be upgraded automatically, and your API token will change.</p>
       </section>
 
 


### PR DESCRIPTION
Closes #340

- Reword the sponsor upgrade timing claim to not quantify a delay we don't control ("upgraded automatically" instead of "within an hour"), while still stating the API token changes.
- Remove `<b>` emphasis on the request-limit sentence.
- Un-nest the `<ol>` from the enclosing `<p>` — the old markup was invalid (a block element inside a paragraph); the list is now a sibling.

Verified:
- `git grep "within an hour"` returns nothing.
- No `<b>`/`<strong>` remains in the sponsor section.
- Full RSpec suite: 1129 examples, 0 failures.
- RuboCop: 0 offenses.

Touches: `app/views/home/donate.html.erb`