### PR TITLE
Preload synonyms/plant on the plants endpoints to kill an N+1

### DIFF
--- a/app/controllers/api/v1/plants_controller.rb
+++ b/app/controllers/api/v1/plants_controller.rb
@@ -121,7 +121,12 @@ class Api::V1::PlantsController < Api::ApiController
     @collection = Genus.friendly.find(params[:genus_id]).species.plants if params[:genus_id]
     @collection = Zone.friendly.find(params[:zone_id].to_s.downcase).all_species.plants if params[:zone_id]
 
-    @collection ||= Species.plants.includes(:genus)
+    @collection ||= Species.plants
+
+    # SpeciesLightSerializer reads `synonyms` and `plant.slug` on top of
+    # `genus`, so all three need preloading regardless of which branch
+    # above set @collection (see #281).
+    @collection = @collection.preload(:plant, :genus, :synonyms)
 
     @collection = apply_filters(@collection, Api::V1::SpeciesController::FILTERABLE_FIELDS)
     @collection = apply_filters_not(@collection, Api::V1::SpeciesController::FILTERABLE_NOT_FIELDS)

--- a/app/models/plant.rb
+++ b/app/models/plant.rb
@@ -85,28 +85,32 @@ class Plant < ApplicationRecord
     puts "Failed to save: #{errors.messages}" unless save
   end
 
+  # PlantSerializer renders each of the six collections below through
+  # SpeciesLightSerializer, which reads `synonyms` and `plant.slug` on top
+  # of `genus` for every row: preload all three or /api/v1/plants/:id pays
+  # two extra queries per species (see #281).
   def species_species
-    species.species_rank
+    species.species_rank.preload(:plant, :genus, :synonyms)
   end
 
   def subspecies
-    species.ssp_rank
+    species.ssp_rank.preload(:plant, :genus, :synonyms)
   end
 
   def varieties
-    species.var_rank
+    species.var_rank.preload(:plant, :genus, :synonyms)
   end
 
   def hybrids
-    species.hybrid_rank
+    species.hybrid_rank.preload(:plant, :genus, :synonyms)
   end
 
   def forms
-    species.form_rank
+    species.form_rank.preload(:plant, :genus, :synonyms)
   end
 
   def subvarieties
-    species.subvar_rank
+    species.subvar_rank.preload(:plant, :genus, :synonyms)
   end
 
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,6 +1,7 @@
 require File.expand_path('./spec_helper', __dir__)
 require File.expand_path('./support/json_api_helper', __dir__)
 require File.expand_path('./support/json_schema_matcher', __dir__)
+require File.expand_path('./support/query_counter', __dir__)
 require File.expand_path('./support/shared_examples/collection_endpoints', __dir__)
 require File.expand_path('./support/shared_examples/api_errors', __dir__)
 require File.expand_path('./support/test_seeds', __dir__)
@@ -43,6 +44,7 @@ RSpec.configure do |config|
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Warden::Test::Helpers
   config.include JsonApiHelper
+  config.include QueryCounter, type: :request
 
   config.use_transactional_fixtures = true
 

--- a/spec/requests/api/v1/plants_preload_spec.rb
+++ b/spec/requests/api/v1/plants_preload_spec.rb
@@ -1,0 +1,97 @@
+require 'rails_helper'
+
+# Regression guard for #281: SpeciesLightSerializer reads `synonyms` and
+# `plant.slug` for every row it serializes. Without preloading both
+# associations (on top of `genus`), the plants collection pays two extra
+# queries per row — pin the query count so it can't grow with the page
+# again instead of guessing at a fixed number.
+RSpec.describe 'Plants collection preloading', type: :request do
+
+  # Distinct lowercase epithets: ScientificNameStructureValidator requires
+  # letters/hyphens only (no digits) for each part of the binomial.
+  let(:epithets) { %w[unus duo tria quattuor quinque sex septem] }
+
+  # Eager (`let!`) so the user row is created before the first
+  # count_queries block runs — otherwise `user.token` lazily inserts the
+  # user on the first call only, throwing the baseline count off by four.
+  let!(:user) { create(:user) }
+  let(:genus) { Genus.first }
+
+  def create_root_plant!(epithet)
+    species = create(:species, genus: genus, scientific_name: "#{genus.name} #{epithet}")
+    Synonym.create!(record: species, name: "#{species.scientific_name}-old")
+    species
+  end
+
+  def create_variety!(root_species, epithet)
+    species = create(
+      :species,
+      genus: genus,
+      rank: 'var',
+      main_species: root_species,
+      scientific_name: "#{root_species.scientific_name} var. #{epithet}"
+    )
+    Synonym.create!(record: species, name: "#{species.scientific_name}-old")
+    species
+  end
+
+  it 'keeps the query count flat as more plants (each with a synonym) are added on /api/v1/plants' do
+    create_root_plant!(epithets[0])
+
+    baseline = count_queries { get '/api/v1/plants', params: { token: user.token } }
+    expect(response).to have_http_status(:ok)
+
+    epithets[1..].each {|epithet| create_root_plant!(epithet) }
+
+    with_more_rows = count_queries { get '/api/v1/plants', params: { token: user.token } }
+    expect(response).to have_http_status(:ok)
+
+    expect(with_more_rows).to eq(baseline)
+  end
+
+  it 'keeps the query count flat on /api/v1/genus/:genus_id/plants (that branch preloaded nothing at all)' do
+    create_root_plant!(epithets[0])
+
+    baseline = count_queries { get "/api/v1/genus/#{genus.slug}/plants", params: { token: user.token } }
+    expect(response).to have_http_status(:ok)
+
+    epithets[1..].each {|epithet| create_root_plant!(epithet) }
+
+    with_more_rows = count_queries { get "/api/v1/genus/#{genus.slug}/plants", params: { token: user.token } }
+    expect(response).to have_http_status(:ok)
+
+    expect(with_more_rows).to eq(baseline)
+  end
+
+  it 'keeps the query count flat on /api/v1/distributions/:zone_id/plants (that branch also preloaded nothing at all)' do
+    zone = Zone.first
+    create_root_plant!(epithets[0]).species_distributions.create!(zone: zone)
+
+    baseline = count_queries { get "/api/v1/distributions/#{zone.slug}/plants", params: { token: user.token } }
+    expect(response).to have_http_status(:ok)
+
+    epithets[1..].each {|epithet| create_root_plant!(epithet).species_distributions.create!(zone: zone) }
+
+    with_more_rows = count_queries { get "/api/v1/distributions/#{zone.slug}/plants", params: { token: user.token } }
+    expect(response).to have_http_status(:ok)
+
+    expect(with_more_rows).to eq(baseline)
+  end
+
+  it 'keeps the query count flat on the nested species collections of /api/v1/plants/:id (PlantSerializer)' do
+    root = create_root_plant!('radix')
+    plant = root.plant
+    create_variety!(root, epithets[0])
+
+    baseline = count_queries { get "/api/v1/plants/#{plant.slug}", params: { token: user.token } }
+    expect(response).to have_http_status(:ok)
+
+    epithets[1..].each {|epithet| create_variety!(root, epithet) }
+
+    with_more_rows = count_queries { get "/api/v1/plants/#{plant.slug}", params: { token: user.token } }
+    expect(response).to have_http_status(:ok)
+
+    expect(with_more_rows).to eq(baseline)
+  end
+
+end

--- a/spec/support/query_counter.rb
+++ b/spec/support/query_counter.rb
@@ -1,0 +1,19 @@
+# Counts real SQL statements executed inside a block. Used to pin an N+1
+# regression: assert the query count stays flat as the number of records in
+# the response grows, instead of guessing at a fixed "magic number".
+module QueryCounter
+  IGNORED_PAYLOAD_NAMES = %w[SCHEMA CACHE].freeze
+  IGNORED_SQL = /\A\s*(BEGIN|COMMIT|SAVEPOINT|RELEASE)/i
+
+  def count_queries(&block)
+    count = 0
+
+    counter = lambda do |*, payload|
+      count += 1 unless IGNORED_PAYLOAD_NAMES.include?(payload[:name]) || payload[:sql].match?(IGNORED_SQL)
+    end
+
+    ActiveSupport::Notifications.subscribed(counter, 'sql.active_record', &block)
+
+    count
+  end
+end


### PR DESCRIPTION
Closes #78, closes #281.

`Api::V1::PlantsController#collection` only preloaded `:genus` on its default branch — the `genus_id`- and `zone_id`-scoped branches preloaded nothing at all. `SpeciesLightSerializer` reads `object.synonyms` and `object.plant.slug` for every row, so all three branches paid two extra queries per record (about forty per 20-item page). Preload `:plant, :genus, :synonyms` uniformly after the branch, matching the pattern already used by `Api::V1::SpeciesController#collection` and `Explore::SpeciesController#index` (both already correct, no change needed there).

Per production evidence posted on #281 (Sentry API-61/API-62), the same gap hits `#show`: `PlantSerializer` renders six `has_many` collections (`species_species`, `subspecies`, `varieties`, `hybrids`, `forms`, `subvarieties`), each built from a plain scope method on `Plant` and each serialized through `SpeciesLightSerializer`. Preloaded the same three associations there.

Added a query-count regression spec (`spec/support/query_counter.rb` + `spec/requests/api/v1/plants_preload_spec.rb`) covering all three collection branches (`/api/v1/plants`, `/api/v1/genus/:genus_id/plants`, `/api/v1/distributions/:zone_id/plants`) plus the nested `#show` collections, so this can't silently regress.

Checked other API v1 collection endpoints for the same omission: `SpeciesLightSerializer` is only used by `plants_controller.rb` and `species_controller.rb`; the latter was already correct.

Touches: `app/controllers/api/v1/plants_controller.rb`, `app/models/plant.rb`, `spec/requests`, `spec/support`

## Testing
- `bundle exec rspec spec/requests/api/v1/plants_preload_spec.rb spec/requests/api/v1/2_plants_spec.rb spec/controllers/api/v1/plants_controller_spec.rb spec/requests/api/v1/3_species_spec.rb spec/controllers/api/v1/species_controller_spec.rb` — 454 examples, 0 failures
- Full suite: 1132 examples, 87 failures — same 87 pre-existing failures as on `master` (verified via stash-and-rerun), none new
- `bundle exec rubocop` — 0 offenses
- `bundle exec brakeman` — 0 warnings