### PR TITLE
Build the explore browse indexes concurrently

### DIFF
--- a/db/migrate/20260907090000_add_explore_browse_indexes_to_species.rb
+++ b/db/migrate/20260907090000_add_explore_browse_indexes_to_species.rb
@@ -1,9 +1,16 @@
 # The explore browse page sorts by completion_ratio and reviewed_at and
 # filters by family_name; none of these had an index (~400k rows).
 class AddExploreBrowseIndexesToSpecies < ActiveRecord::Migration[8.0]
+  # A plain CREATE INDEX takes an ACCESS EXCLUSIVE lock for the whole build,
+  # which on a table this size means the API's busiest table stops answering
+  # three times in a row during the deploy migration. Build them concurrently
+  # instead, as 20260905053000_add_index_on_species_wiki_score already does.
+  # CREATE INDEX CONCURRENTLY cannot run inside a transaction.
+  disable_ddl_transaction!
+
   def change
-    add_index :species, :completion_ratio
-    add_index :species, :reviewed_at
-    add_index :species, :family_name
+    add_index :species, :completion_ratio, algorithm: :concurrently
+    add_index :species, :reviewed_at, algorithm: :concurrently
+    add_index :species, :family_name, algorithm: :concurrently
   end
 end


### PR DESCRIPTION
Pre-release fix, found while reviewing what v2.5.0 would run against production.

`20260907090000_add_explore_browse_indexes_to_species` builds three indexes on `species` with a plain `add_index`:

```ruby
add_index :species, :completion_ratio
add_index :species, :reviewed_at
add_index :species, :family_name
```

`CREATE INDEX` without `CONCURRENTLY` holds an **ACCESS EXCLUSIVE** lock on the table for the whole build — reads and writes both blocked. On `species` (~489k rows) that is the API's busiest table refusing to answer, three times in a row, during the deploy migration. Self-inflicted downtime in the release window.

The repo already does this correctly one migration earlier: `20260905053000_add_index_on_species_wiki_score` uses `disable_ddl_transaction!` + `algorithm: :concurrently`, with a comment explaining why. This restores that convention rather than inventing one.

## Why editing a merged migration is safe here

- **It has not run in production.** Production is still on v2.4.0; this migration and the fix ship together in v2.5.0, so production only ever sees the concurrent form.
- **Environments that already ran it are unaffected.** The version stays in `schema_migrations` and is not replayed.
- **No schema drift either way.** `algorithm:` is not recorded in `schema.rb`, so a database built from the old form and one built from the new are identical — same three indexes, same names. `db/schema.rb` is untouched by this PR.

Had production already run it, the correct move would have been a new migration dropping and recreating each index concurrently. That is not needed.

## Verification

- `verify.sh` green: RuboCop clean, `1134 examples, 0 failures`.
- Only the migration file changes; `git status` shows nothing else.

Touches: `db/migrate/20260907090000_add_explore_browse_indexes_to_species.rb`
