### PR TITLE
Let a pending user read the terms they are asked to accept

### DIFF
--- a/app/controllers/concerns/requires_terms_acceptance.rb
+++ b/app/controllers/concerns/requires_terms_acceptance.rb
@@ -28,6 +28,12 @@ module RequiresTermsAcceptance
     return unless user_signed_in?
     return if devise_controller?
     return if controller_path == 'terms_acceptances'
+    # The terms themselves must stay readable, or the gate asks people to accept
+    # a document they cannot open: the acceptance form links to `terms_path`
+    # (shared/_terms_checkbox_field), and without this the link bounces straight
+    # back to the form. `/terms` is home#licence, so `controller_path` is 'home'
+    # and the exemption above does not cover it.
+    return if request.path == terms_path
     return if controller_path.start_with?('api/')
     return if current_user.terms_up_to_date?
 

--- a/spec/requests/terms_acceptances_spec.rb
+++ b/spec/requests/terms_acceptances_spec.rb
@@ -24,6 +24,25 @@ RSpec.describe 'Terms acceptance', type: :request do
       expect(response).to redirect_to(new_terms_acceptance_path(return_to: explore_path))
     end
 
+    it 'leaves /terms readable, so a pending user can read what they are asked to accept' do
+      login_as pending_user, scope: :user
+
+      get terms_path
+
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'keeps the acceptance form\'s own Terms of Use link working rather than bouncing it back' do
+      login_as pending_user, scope: :user
+
+      get new_terms_acceptance_path
+      expect(response.body).to include(terms_path)
+
+      get terms_path
+
+      expect(response).not_to redirect_to(new_terms_acceptance_path(return_to: terms_path))
+    end
+
     it 'redirects a signed-in user whose accepted version is stale' do
       # Built stale from the start (accepts_terms: false so the before_save
       # callback doesn't stamp it as current) rather than accepted-then-mutated:


### PR DESCRIPTION
Reported from production on 2.5.0: a signed-in user who has not accepted the current terms is asked to accept them and cannot read them. Opening https://trefle.io/terms redirects straight back to the acceptance form.

## The loop

`RequiresTermsAcceptance` exempts the acceptance form by controller:

```ruby
return if controller_path == 'terms_acceptances'
```

But `/terms` is a different controller — `config/routes.rb:14` maps it to `home#licence`, so its `controller_path` is `home`. The gate catches it and redirects to `new_terms_acceptance_path`.

The form links there itself. `shared/_terms_checkbox_field` renders:

```erb
I have read and accept the <%= link_to "Terms of Use", terms_path, target: "_blank", rel: "noopener" %>
```

So the only route offered for reading the document bounces back to the demand to sign it. There is no other way to reach the terms while gated.

Beyond the UX, the clause being accepted is the binding attribution clause from #320 — worth being readable before it is agreed to.

## Fix

Exempt the terms page by path, next to the existing exemptions:

```ruby
return if request.path == terms_path
```

Path rather than `controller_path`, because `home` also serves `/`, `/about`, `/donate` and `/citation`, which should stay gated.

## Verification

Two specs added, both failing before the change and passing after:

```
Failures without the fix:
  1) ... leaves /terms readable, so a pending user can read what they are asked to accept
  2) ... keeps the acceptance form's own Terms of Use link working rather than bouncing it back
19 examples, 2 failures
```

with the fix: `19 examples, 0 failures`. Full suite: `1136 examples, 0 failures`, RuboCop clean.

## Why the existing specs missed it

`spec/requests/terms_acceptances_spec.rb` already had 17 examples, thorough about the gate's reach — it asserts explore pages are gated, that the JSON API never is, that Devise pages stay open so a pending user can sign out, and that anonymous visitors pass. None of them asked whether the person being gated can read what they are agreeing to. The suite tested the gate from the operator's side only.

Touches: `app/controllers/concerns/requires_terms_acceptance.rb`, `spec/requests/terms_acceptances_spec.rb`
Blocked by: none
