### PR TITLE
Seed the WFO licence, and report the slugs that find no row

### DIFF
--- a/lib/migrators/source_licences.rb
+++ b/lib/migrators/source_licences.rb
@@ -2,10 +2,9 @@
 # 2026-09-07. Only sources with a confirmed licence are seeded here — every
 # other source (IPNI, PlantNet, pfaf, flora_*...) stays NULL, never guessed.
 #
-# Matches by slug only, and never creates a ForeignSource: `db/botanic_seeds.rb`
-# (the tracked seed data) has no WFO entry, so if production hasn't crawled a
-# WFO-linked species yet, that row doesn't exist and this run no-ops for it —
-# safe to re-run once it does.
+# Never creates a ForeignSource: it seeds a licence onto a row that already
+# exists, and reports the slugs it could not find instead of passing over them.
+# Matching is case-insensitive because the stored casing is not uniform.
 module Migrators
   class SourceLicences
 
@@ -27,14 +26,30 @@ module Migrators
       }
     }.freeze
 
+    # Slug casing is not consistent in foreign_sources -- WFO and IPNI are
+    # stored upper-case, everything else lower-case -- so an exact match
+    # silently skipped WFO and left the biggest taxonomic source without its
+    # licence in production. Match case-insensitively, and say what was missed
+    # rather than returning as if all four had been seeded.
     def self.run
-      LICENCES.each do |slug, attrs|
-        fs = ForeignSource.find_by(slug: slug)
+      seeded = []
+      missing = []
 
-        next unless fs
+      LICENCES.each do |slug, attrs|
+        fs = ForeignSource.where('lower(slug) = ?', slug.downcase).first
+
+        if fs.nil?
+          missing << slug
+          next
+        end
 
         fs.update!(attrs)
+        seeded << fs.slug
       end
+
+      Rails.logger.warn("[SourceLicences] no foreign_source for #{missing.join(', ')}") if missing.any?
+
+      { seeded: seeded, missing: missing }
     end
 
   end

--- a/spec/lib/migrators_spec.rb
+++ b/spec/lib/migrators_spec.rb
@@ -120,12 +120,26 @@ RSpec.describe Migrators do
       expect(powo.reload.licence_url).to eq('https://creativecommons.org/licenses/by/4.0/')
     end
 
-    it 'seeds a source that is not part of the fixed seed set (WFO)' do
-      wfo = ForeignSource.create!(name: 'World Flora Online', slug: 'wfo')
+    it 'seeds WFO, whose slug is stored upper-case in production' do
+      # Built as 'WFO' on purpose: the previous version of this example created
+      # it as 'wfo', the exact string the mapping looks up, so it asserted the
+      # mapping against itself and stayed green while production had no licence
+      # on its largest taxonomic source.
+      wfo = ForeignSource.create!(name: 'World Flora Online', slug: 'WFO')
 
       described_class.run
 
       expect(wfo.reload.licence).to eq('CC0-1.0')
+      expect(wfo.reload.licence_url).to eq('https://creativecommons.org/publicdomain/zero/1.0/')
+    end
+
+    it 'reports a mapped slug that has no row rather than skipping it silently' do
+      ForeignSource.where('lower(slug) = ?', 'usda').delete_all
+
+      result = described_class.run
+
+      expect(result[:missing]).to include('usda')
+      expect(result[:seeded]).not_to include('usda')
     end
 
     it 'leaves an unconfirmed source at NULL rather than guess' do


### PR DESCRIPTION
Closes #348.

Ran `Migrators::SourceLicencesWorker` on production on 2026-09-09, right after the 2.5.0 rollout. It seeded three of the four mapped sources and reported nothing about the fourth:

```
powo  -> CC-BY-4.0                OK
gbif  -> CC-BY-4.0                OK
usda  -> Public domain (US Gov)   OK
wfo   -> CC0-1.0                  NOT APPLIED
```

WFO is stored as `WFO`; the mapping key is `wfo`; `find_by(slug:)` missed it and `next unless fs` dropped it silently. Two of the seventeen slugs are upper-case — `WFO` and `IPNI` — so the same trap was waiting for IPNI the day its licence is confirmed.

This is user-visible. On production the API returned:

```json
{"id": "wfo-0000000003", "name": "WFO", "licence": null, "licence_url": null}
```

while GBIF on the same payload carried `"licence": "CC-BY-4.0"`. Naming each source's licence is the point of #318/#324, and it was half-delivered on the largest taxonomic source.

## Change

- Case-insensitive slug match.
- `run` returns `{seeded:, missing:}` and logs the misses. A run that seeds 3 of 4 was previously indistinguishable from one that seeded 4 of 4.
- The header comment carried the wrong diagnosis — it reasoned that WFO might not exist yet because `db/botanic_seeds.rb` has no entry for it. The row does exist, and re-running would never have fixed it. Corrected.

## The spec could not have caught it

```ruby
wfo = ForeignSource.create!(name: 'World Flora Online', slug: 'wfo')
described_class.run
expect(wfo.reload.licence).to eq('CC0-1.0')
```

It created the row with the exact string the mapping looks up, so it asserted the mapping against itself and stayed green while production was wrong. It now builds `WFO` and fails if the lookup is made case-sensitive again. A second example covers the reporting path.

Both new examples fail on master and pass here:

```
without the fix: 15 examples, 2 failures
with the fix:    15 examples, 0 failures
full suite:      1137 examples, 0 failures
```

## After merge

The worker needs re-running on production to seed WFO. It is idempotent.

Deliberately unchanged: the policy of seeding only confirmed licences and never guessing. The other thirteen sources stay NULL.

Touches: `lib/migrators/source_licences.rb`, `spec/lib/migrators_spec.rb`
